### PR TITLE
Enable pass running on module

### DIFF
--- a/include/NeuraDialect/NeuraOps.td
+++ b/include/NeuraDialect/NeuraOps.td
@@ -60,7 +60,7 @@ def Neura_FAddFAddOp : Op<NeuraDialect, "fadd_fadd"> {
 }
 
 def Neura_FMulFAddOp : Op<NeuraDialect, "fmul_fadd"> {
-  let summary = "Fused fmul(fadd(a, b), c)";
+  let summary = "Fused fadd(fmul(a, b), c)";
   let arguments = (ins AnyFloat:$a, AnyFloat:$b, AnyFloat:$c);
   let results = (outs AnyFloat:$result);
   // let assemblyFormat = "$a `,` $b `,` $c attr-dict `:` type($result)";

--- a/include/NeuraDialect/NeuraOps.td
+++ b/include/NeuraDialect/NeuraOps.td
@@ -22,6 +22,35 @@ def Neura_FAddOp : Op<NeuraDialect, "fadd"> {
   let traits = [SameOperandsAndResultElementType];
 }
 
+// Defines a multiplication operation.
+def Neura_FMulOp : Op<NeuraDialect, "fmul"> {
+  let summary = "Floating multiplication operation";
+  let opName = "fmul";
+  let arguments = (ins AnyFloat:$lhs, AnyFloat:$rhs);
+  let results = (outs AnyFloat:$result);
+  // let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($result)";
+  let traits = [SameOperandsAndResultElementType];
+}
+
+def VectorOfAnyFloat :
+  TypeConstraint<
+    CPred<
+      "mlir::isa<::mlir::VectorType>($_self) && "
+      "mlir::isa<::mlir::FloatType>(mlir::cast<::mlir::VectorType>($_self).getElementType())"
+    >,
+    "vector of floats"
+  >;
+
+// Defines a vector multiplication operation.
+def Neura_VFMulOp : Op<NeuraDialect, "vfmul"> {
+  let summary = "Vector floating multiplication operation";
+  let opName = "vfmul";
+  let arguments = (ins VectorOfAnyFloat:$lhs, VectorOfAnyFloat:$rhs);
+  let results = (outs VectorOfAnyFloat:$result);
+  // let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($result)";
+  let traits = [SameOperandsAndResultElementType];
+}
+
 def Neura_FAddFAddOp : Op<NeuraDialect, "fadd_fadd"> {
   let summary = "Fused fadd(fadd(a, b), c)";
   let arguments = (ins AnyFloat:$a, AnyFloat:$b, AnyFloat:$c);
@@ -30,6 +59,13 @@ def Neura_FAddFAddOp : Op<NeuraDialect, "fadd_fadd"> {
   let traits = [SameOperandsAndResultElementType];
 }
 
+def Neura_FMulFAddOp : Op<NeuraDialect, "fmul_fadd"> {
+  let summary = "Fused fmul(fadd(a, b), c)";
+  let arguments = (ins AnyFloat:$a, AnyFloat:$b, AnyFloat:$c);
+  let results = (outs AnyFloat:$result);
+  // let assemblyFormat = "$a `,` $b `,` $c attr-dict `:` type($result)";
+  let traits = [SameOperandsAndResultElementType];
+}
 
 // Defines a move operation for data communication.
 def Neura_MovOp : Op<NeuraDialect, "mov"> {

--- a/lib/Conversion/LlvmToNeura/LlvmToNeuraPatterns.td
+++ b/lib/Conversion/LlvmToNeura/LlvmToNeuraPatterns.td
@@ -7,3 +7,4 @@ def : Pat<
   (LLVM_FAddOp $lhs, $rhs, $_fastmath),
   (Neura_FAddOp $lhs, $rhs)
 >;
+

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -16,6 +16,7 @@ add_mlir_library(NeuraTransforms
   LINK_LIBS PUBLIC
     MLIRIR
     MLIRFuncDialect
+    MLIRLLVMDialect
     MLIRPass
     MLIRSupport
     MLIRTransformUtils

--- a/lib/Transforms/FusePatternsPass.cpp
+++ b/lib/Transforms/FusePatternsPass.cpp
@@ -8,30 +8,92 @@ using namespace mlir;
 
 namespace {
 
-struct FuseFAddFAddPattern : public RewritePattern {
-  FuseFAddFAddPattern(MLIRContext *ctx)
-      : RewritePattern("neura.fadd", /*benefit=*/1, ctx) {}
+struct FuseFAddFAddPattern : public OpRewritePattern<neura::FAddOp> {
+  using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(Operation *op, PatternRewriter &rewriter) const override {
-    auto first = dyn_cast<neura::FAddOp>(op);
-    if (!first || !first->hasOneUse()) return failure();
+  LogicalResult matchAndRewrite(neura::FAddOp second,
+                                PatternRewriter &rewriter) const override {
+    Value lhs = second.getLhs();
+    Value rhs = second.getRhs();
 
-    auto user = dyn_cast<neura::FAddOp>(*first->getUsers().begin());
-    if (!user) return failure();
+    auto lhs_op = lhs.getDefiningOp<neura::FAddOp>();
+    auto rhs_op = rhs.getDefiningOp<neura::FAddOp>();
 
-    Location loc = user.getLoc();
-    Type type = user.getType();
+    neura::FAddOp first = nullptr;
+    Value tail;
 
-    auto fused = rewriter.create<neura::FAddFAddOp>(loc, type,
-      first.getLhs(), first.getRhs(), user.getRhs());
+    // Case 1: LHS is another fadd.
+    if (lhs_op && second.getRhs()) {
+      first = lhs_op;
+      tail = second.getRhs();
+    }
+    // Case 2: RHS is another fadd.
+    else if (rhs_op && second.getLhs()) {
+      first = rhs_op;
+      tail = second.getLhs();
+    }
 
-    rewriter.replaceOp(user, fused.getResult());
+    if (!first)
+      return failure();
+
+    // Only fuses if the first fadd is not reused elsewhere.
+    if (!first->hasOneUse())
+      return failure();
+
+    Location loc = second.getLoc();
+    Type type = second.getType();
+
+    auto fused = rewriter.create<neura::FAddFAddOp>(
+        loc, type, first.getLhs(), first.getRhs(), tail);
+
+    rewriter.replaceOp(second, fused.getResult());
     rewriter.eraseOp(first);
     return success();
   }
 };
 
-struct FusePatternsPass : public PassWrapper<FusePatternsPass, OperationPass<func::FuncOp>> {
+struct FuseFMulFAddPattern : public OpRewritePattern<neura::FAddOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(neura::FAddOp add,
+                                PatternRewriter &rewriter) const override {
+    auto lhs_op = add.getLhs().getDefiningOp<neura::FMulOp>();
+    auto rhs_op = add.getRhs().getDefiningOp<neura::FMulOp>();
+
+    neura::FMulOp fmul = nullptr;
+    Value other;
+
+    // Case 1: fmul is on the LHS.
+    if (lhs_op && add.getRhs()) {
+      fmul = lhs_op;
+      other = add.getRhs();
+    }
+    // Case 2: fmul is on the RHS.
+    else if (rhs_op && add.getLhs()) {
+      fmul = rhs_op;
+      other = add.getLhs();
+    }
+
+    if (!fmul)
+      return failure();
+
+    // Optional: only fuses if fmul has a single use.
+    if (!fmul->hasOneUse())
+      return failure();
+
+    Location loc = add.getLoc();
+    Type type = add.getType();
+
+    auto fused = rewriter.create<neura::FMulFAddOp>(
+        loc, type, fmul.getLhs(), fmul.getRhs(), other);
+
+    rewriter.replaceOp(add, fused.getResult());
+    rewriter.eraseOp(fmul);
+    return success();
+  }
+};
+
+struct FusePatternsPass : public PassWrapper<FusePatternsPass, OperationPass<ModuleOp>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(FusePatternsPass)
 
   StringRef getArgument() const override { return "fuse-patterns"; }
@@ -39,9 +101,23 @@ struct FusePatternsPass : public PassWrapper<FusePatternsPass, OperationPass<fun
 
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
-    patterns.add<FuseFAddFAddPattern>(&getContext());
-    if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
-      signalPassFailure();
+    patterns.add<FuseFAddFAddPattern>(&getContext(), 2);
+    patterns.add<FuseFMulFAddPattern>(&getContext(), 3);
+    FrozenRewritePatternSet frozen(std::move(patterns));
+
+    ModuleOp module_op = getOperation();
+
+    // Applies to every region inside the module (regardless of func type,
+    // e.g., mlir func or llvm func).
+    module_op.walk([&](Operation *op) {
+      if (!op->getRegions().empty()) {
+        for (Region &region : op->getRegions()) {
+          if (failed(applyPatternsAndFoldGreedily(region, frozen))) {
+            signalPassFailure();
+          }
+        }
+      }
+    });
   }
 };
 

--- a/test/neura/fadd_fadd.mlir
+++ b/test/neura/fadd_fadd.mlir
@@ -1,3 +1,4 @@
+// Applies pattern fusion before mov insertion.
 // RUN: mlir-neura-opt --lower-arith-to-neura --fuse-patterns --insert-mov %s | FileCheck %s
 
 func.func @test(%a: f32, %b: f32) -> f32 {

--- a/test/neura/for_loop/kernel.cpp
+++ b/test/neura/for_loop/kernel.cpp
@@ -40,6 +40,7 @@ void kernel(float input[], float output[], float coefficient[]) {
   int j = 0;
 
    for (i = 0; i < NTAPS; ++i) {
-     output[j] += input[i] * coefficient[i];
+     float tmp = input[i] * coefficient[i];
+     output[j] += tmp;
    }
 }

--- a/test/neura/for_loop/kernel.cpp
+++ b/test/neura/for_loop/kernel.cpp
@@ -1,0 +1,45 @@
+// RUN: mlir-neura-opt %s | FileCheck %s
+
+#include <stdio.h>
+
+#define NTAPS 32
+
+float input[NTAPS] = {
+1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0
+};
+float output[NTAPS];
+float coefficients[NTAPS] = {0.25, 1.50, 3.75, -2.25, 0.50, 0.75, -3.00, 1.25,
+0.25, 1.50, 3.75, -2.25, 0.50, 0.75, -3.00, 1.25,
+0.25, 1.50, 3.75, -2.25, 0.50, 0.75, -3.00, 1.25,
+0.25, 1.50, 3.75, -2.25, 0.50, 0.75, -3.00, 1.25};
+
+void kernel(float input[], float output[], float coefficient[]);
+
+int main()
+{
+
+//  input_dsp (input, NTAPS, 0);
+
+  kernel(input, output, coefficients);
+
+//  output_dsp (input, NTAPS, 0);
+//  output_dsp (coefficients, NTAPS, 0);
+//  output_dsp (output, NTAPS, 0);
+  printf("output: %f\n", output[0]);
+  return 0;
+}
+
+/*   input :           input sample array */
+/*   output:           output sample array */
+/*   coefficient:      coefficient array */
+void kernel(float input[], float output[], float coefficient[]) {
+  int i;
+  int j = 0;
+
+   for (i = 0; i < NTAPS; ++i) {
+     output[j] += input[i] * coefficient[i];
+   }
+}

--- a/test/neura/for_loop/test.mlir
+++ b/test/neura/for_loop/test.mlir
@@ -1,0 +1,14 @@
+// Compiles the original kernel to mlir, then lower back to llvm, eventually binary.
+// RUN: clang++ -S -emit-llvm -o %t-kernel.ll kernel.cpp
+// RUN: mlir-translate --import-llvm %t-kernel.ll -o %t-kernel.mlir
+
+// Lowers to neura.
+// RUN: mlir-neura-opt \
+// RUN:   --lower-llvm-to-neura \
+// RUN:   --insert-mov %t-kernel.mlir | \
+// RUN:   FileCheck %s
+
+// Verifies the neura ops are generated.
+// CHECK:      [[LHS:%.*]] = neura.mov %{{.*}}
+// CHECK-NEXT: [[RHS:%.*]] = neura.mov %{{.*}}
+// CHECK-NEXT: [[RES:%.*]] = "neura.add"([[LHS]], [[RHS]])

--- a/test/neura/for_loop/test.mlir
+++ b/test/neura/for_loop/test.mlir
@@ -1,14 +1,18 @@
 // Compiles the original kernel to mlir, then lower back to llvm, eventually binary.
-// RUN: clang++ -S -emit-llvm -o %t-kernel.ll kernel.cpp
+// RUN: clang++ -S -emit-llvm -O2 -o %t-kernel.ll kernel.cpp
 // RUN: mlir-translate --import-llvm %t-kernel.ll -o %t-kernel.mlir
 
 // Lowers to neura.
 // RUN: mlir-neura-opt \
 // RUN:   --lower-llvm-to-neura \
-// RUN:   --insert-mov %t-kernel.mlir | \
-// RUN:   FileCheck %s
+// RUN:   --fuse-patterns \
+// RUN:   --insert-mov \
+// RUN:   %t-kernel.mlir | FileCheck %s
 
-// Verifies the neura ops are generated.
+// Verifies the neura ops are generated. And fusion happens.
+// CHECK:      "neura.vfmul"
+// CHECK:      "neura.add"
+// CHECK:      "neura.fmul_fadd"
 // CHECK:      [[LHS:%.*]] = neura.mov %{{.*}}
 // CHECK-NEXT: [[RHS:%.*]] = neura.mov %{{.*}}
 // CHECK-NEXT: [[RES:%.*]] = "neura.add"([[LHS]], [[RHS]])

--- a/tools/mlir-neura-opt/CMakeLists.txt
+++ b/tools/mlir-neura-opt/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(mlir-neura-opt
 target_link_libraries(mlir-neura-opt PRIVATE
   MLIRDialect       # MLIR Dialect
   MLIRIR            # MLIR Core IR
+  MLIRDLTIDialect
   MLIRLLVMDialect
   MLIROptLib        # MLIR optimizer library
   MLIRSupport       # MLIR Support utilities

--- a/tools/mlir-neura-opt/mlir-neura-opt.cpp
+++ b/tools/mlir-neura-opt/mlir-neura-opt.cpp
@@ -1,5 +1,6 @@
 // tools/mlir-neura-opt/mlir-neura-opt.cpp
 
+#include "mlir/Dialect/DLTI/DLTI.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllPasses.h"
@@ -18,6 +19,7 @@ int main(int argc, char **argv) {
   registry.insert<mlir::neura::NeuraDialect>();
   registry.insert<mlir::func::FuncDialect>();
   registry.insert<mlir::arith::ArithDialect>();
+  registry.insert<mlir::DLTIDialect>();
   registry.insert<mlir::LLVM::LLVMDialect>();
 
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
@@ -29,7 +31,6 @@ int main(int argc, char **argv) {
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return mlir::neura::createInsertMovPass();
   });
-
   mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
     return mlir::neura::createFusePatternsPass();
   });


### PR DESCRIPTION
- Enable lower passes to work on `ModuleOp`
  - To make it be able to parse both llvm.func and mlir.func
  - First step towards https://github.com/coredac/dataflow/issues/10
- Introduce some other basic neura operations (vector floating add, i.e., vfadd) and fusion patterns (mul->add)