### PR TITLE
[feature] Handles terminator for insert mov

### DIFF
--- a/lib/Transforms/InsertMovPass.cpp
+++ b/lib/Transforms/InsertMovPass.cpp
@@ -48,7 +48,15 @@ struct InsertMovForNeuraOps : public RewritePattern {
     state.addTypes(op->getResultTypes());
     state.addAttributes(op->getAttrs());
 
+    // Copies successors for terminator operations.
+    if (op->hasTrait<OpTrait::IsTerminator>()) {
+      for (Block *successor : op->getSuccessors()) {
+        state.addSuccessors(successor);
+      }
+    }
+
     Operation *newOp = rewriter.create(state);
+
     rewriter.replaceOp(op, newOp->getResults());
     return success();
   }

--- a/test/neura/for_loop/test.mlir
+++ b/test/neura/for_loop/test.mlir
@@ -8,7 +8,7 @@
 // RUN:   --assign-accelerator \
 // RUN:   --lower-llvm-to-neura \
 // RUN:   --fuse-patterns \
-// RN:   --insert-mov \
+// RUN:   --insert-mov \
 // RUN:   %t-kernel.mlir | FileCheck %s
 
 // Verifies the neura ops are generated. And fusion happens.


### PR DESCRIPTION
Just re-enable insert-mov in test, handling the terminator.

I plan to support ctrl-flow related mov in another PR, which might be non-trivial. @MeowMJ @HardyVon.