### PR TITLE
Lower Affine Dialect to Nerua Dialect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 add_compile_options(-g)
 
-# set(MLIR_DIR /home/lucas/llvm-project/build/lib/cmake/mlir)
-# set(LLVM_DIR /home/lucas/llvm-project/build/lib/cmake/llvm)
-# set(MLIR_SRC_DIR /home/lucas/llvm-project/mlir)
-# set(MLIR_BINARY_DIR /home/lucas/llvm-project/build)
+set(MLIR_DIR /home/lucas/llvm-project/build/lib/cmake/mlir)
+set(LLVM_DIR /home/lucas/llvm-project/build/lib/cmake/llvm)
+set(MLIR_SRC_DIR /home/lucas/llvm-project/mlir)
+set(MLIR_BINARY_DIR /home/lucas/llvm-project/build)
 message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 add_compile_options(-g)
 
-set(MLIR_DIR /home/lucas/llvm-project/build/lib/cmake/mlir)
-set(LLVM_DIR /home/lucas/llvm-project/build/lib/cmake/llvm)
-set(MLIR_SRC_DIR /home/lucas/llvm-project/mlir)
-set(MLIR_BINARY_DIR /home/lucas/llvm-project/build)
+# set(MLIR_DIR /home/lucas/llvm-project/build/lib/cmake/mlir)
+# set(LLVM_DIR /home/lucas/llvm-project/build/lib/cmake/llvm)
+# set(MLIR_SRC_DIR /home/lucas/llvm-project/mlir)
+# set(MLIR_BINARY_DIR /home/lucas/llvm-project/build)
 message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 

--- a/include/Conversion/ConversionPasses.h
+++ b/include/Conversion/ConversionPasses.h
@@ -19,6 +19,7 @@ namespace mlir {
 // Conversion passes.
 std::unique_ptr<mlir::Pass> createLowerArithToNeuraPass();
 std::unique_ptr<mlir::Pass> createLowerLlvmToNeuraPass();
+std::unique_ptr<mlir::Pass> createLowerAffineToNeuraPass();
 
 #define GEN_PASS_REGISTRATION
 #include "Conversion/ConversionPasses.h.inc"

--- a/include/Conversion/ConversionPasses.td
+++ b/include/Conversion/ConversionPasses.td
@@ -20,4 +20,10 @@ def LowerLlvmToNeura : Pass<"lower-llvm-to-neura", "ModuleOp">{
   let constructor = "mlir::createLowerLlvmToNeuraPass()";
 }
 
+def LowerAffineToNeura : Pass<"lower-affine-to-neura", "FuncOp">{
+  let summary = "Lower affine to Neura dialect";
+  let description = [{Lower affine dialect operations to Neura dialect operations.}];
+  let constructor = "mlir::createLowerAffineToNeuraPass()";
+}
+
 #endif // CONVERSION_PASSES_TD

--- a/include/NeuraDialect/NeuraOps.td
+++ b/include/NeuraDialect/NeuraOps.td
@@ -1,6 +1,7 @@
 // NeuraOps.td - Custom operation definitions.
 
 include "NeuraDialect/NeuraDialect.td"
+include "mlir/IR/CommonTypeConstraints.td"
 
 // ----------------------------------------------------
 // Defines basic scalar operations.
@@ -18,8 +19,8 @@ def Neura_ConstantOp : Op<NeuraDialect, "constant"> {
 def Neura_AddOp : Op<NeuraDialect, "add"> {
   let summary = "Integer addition operation";
   let opName = "add";
-  let arguments = (ins AnyInteger:$lhs, AnyInteger:$rhs, Optional<AnyType>:$predicate);
-  let results = (outs AnyInteger:$result);
+  let arguments = (ins SignlessIntegerLike:$lhs, SignlessIntegerLike:$rhs, Optional<AnyType>:$predicate);
+  let results = (outs SignlessIntegerLike:$result);
   // let assemblyFormat = "$lhs `,` $rhs `,` $predicate attr-dict `:` type($result)";
   let traits = [SameOperandsAndResultElementType];
 }

--- a/include/NeuraDialect/NeuraOps.td
+++ b/include/NeuraDialect/NeuraOps.td
@@ -11,7 +11,7 @@ def Neura_ConstantOp : Op<NeuraDialect, "constant"> {
     OptionalAttr<BoolAttr>:$predicate  // Add optional predicate attribute
   );
   let results = (outs AnyType:$result);
-  // let assemblyFormat = "attr-dict `:` type($result)";
+  let assemblyFormat = "attr-dict `:` type($result)";
 }
 
 // Defines an addition operation.

--- a/include/NeuraDialect/NeuraOps.td
+++ b/include/NeuraDialect/NeuraOps.td
@@ -101,6 +101,34 @@ def Neura_StoreOp : Op<NeuraDialect, "store"> {
   // let assemblyFormat = "$value `,` $addr `,` $predicate attr-dict";
 }
 
+// Defines a load operation with integrated address calculation.
+def Neura_LoadIndexedOp: Op<NeuraDialect, "load_indexed", [AttrSizedOperandSegments]>{
+  let summary = "Load with integrated address calculation for multi-dimensional arrays";
+  let description = [{
+    Calculates the address using the base address and indices.
+    Load the value at the calculated address.
+    Example:
+      %value = neura.load_indexed %base [%arg1, %arg2] : f32
+  }];
+  let arguments = (ins Arg<AnyMemRef, "the load operation">:$base, Variadic<Index>:$indices, Optional<AnyType>:$predicate);
+  let results = (outs AnyType:$result);
+  let assemblyFormat = "type($base) $base `[` $indices `]` ($predicate^ `:` type($predicate))? attr-dict `:` type($result)";
+}
+
+//Defines a store operation with integrated address calculation.
+def Neura_StoreIndexedOp: Op<NeuraDialect, "store_indexed", [AttrSizedOperandSegments]> {
+  let summary = "Store with integrated address calculation for multi-dimensional arrays";
+  let description = [{
+    Calculates the address using the base address and indices.
+    Store the value at the calculated address.
+    Example:
+      neura.store_indexed %value, %base [%arg1, %arg2] : f32
+  }];
+  let arguments = (ins AnyType:$value, Arg<AnyMemRef, "the store operation">:$base, Variadic<Index>:$indices, Optional<AnyType>:$predicate);
+  let results = (outs);
+  let assemblyFormat = "$value `to` type($base) $base `[` $indices `]` ($predicate^ `:` type($predicate))? attr-dict `:` type($value)";
+}
+
 // Defines a pointer computation operation.
 def Neura_GEP : Op<NeuraDialect, "gep"> {
   let summary = "Pointer computation using offset indices";
@@ -252,4 +280,51 @@ def Neura_ReserveOp : Op<NeuraDialect, "reserve"> {
   let arguments = (ins);
   let results = (outs AnyType:$result);
   let assemblyFormat = "attr-dict `:` type($result)";
+}
+
+// ----------------------------------------------------
+// Defines loop related operations.
+
+// Loop iteration operation for index increament and compare
+def Neura_LoopIterOp : Op<NeuraDialect, "loop_iter", [AttrSizedOperandSegments]> {
+  let summary = "CGRA-optimized loop iteration operation";
+  let description = [{
+    Takes the current loop index, a step value, and an upper bound as the inputs.
+    Outputs the next loop index and a boolean condition indicating whether the loop should continue.
+    
+    Example:
+      %next_index, %continue = neura.loop_control current_index: 0, step: 1, bound: 10 : i32 i1}];
+
+  let arguments = (ins Index: $current_index, 
+                   Index:$step, 
+                   Index:$bound,
+                   Optional<AnyType>:$loop_type, // 0: <, 1: <=, 2: >, 3: >=
+                   Optional<AnyType>:$predicate);
+  let results = (outs Index:$next_index, I1:$continue_condition);
+  let assemblyFormat = "`current_index` `:` $current_index `,` `step` `:` $step `,` `bound` `:` $bound `:` type($bound) ($loop_type^ `:` type($loop_type))? ($predicate^ `:` type($predicate))? attr-dict `:` type($next_index) type($continue_condition)";
+}
+
+// Loop control operation that integrates loop iteration and control flow.
+def Neura_LoopControlOp: Op<NeuraDialect, "loop_control", [Terminator]>{
+  let summary = "Intergrated loop control operation for simple loops";
+  let description = [{
+    This operation is an integrated loop control operation that combines the loop iteration and control flow.
+    It has three main actions:
+    1. Calculates the next iteration's index: `next_index = current_index + step`
+    2. Checks if the loop should continue based on the current index and bound.
+    3. If the loop should continue, it branches to the loop body, and yields related values.
+    4. Otherwise, it exits the loop.
+  }];
+  let arguments = (ins Index:$current_index, // Current loop index
+                   Index:$step,
+                   Index:$bound, 
+                   DefaultValuedAttr<StrAttr, "\"lt\"">:$loop_type, // Loop type: "lt", "le", "gt", "ge", "eq", "ne"
+                   Variadic<AnyType>:$passthrough_args // Additional arguments to pass through to the successors
+                   );
+  let results = (outs);
+  let successors = (successor
+                    AnySuccessor:$body, // loop body successors
+                    AnySuccessor:$exit // exit successors
+                    );
+  let assemblyFormat = "`current_index` `:` $current_index `,` `step` `:` $step `,` `bound` `:` $bound `,` `loop_type` `:` $loop_type (`passthrough` `(` $passthrough_args^ `:` type($passthrough_args) `)`)? `then` $body `else` $exit attr-dict";
 }

--- a/lib/Conversion/AffineToNeura/AffineToNeuraPass.cpp
+++ b/lib/Conversion/AffineToNeura/AffineToNeuraPass.cpp
@@ -1,0 +1,317 @@
+#include "Conversion/ConversionPasses.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Region.h"
+#include "mlir/IR/ValueRange.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "NeuraDialect/NeuraDialect.h"
+#include "NeuraDialect/NeuraOps.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "llvm/Support/raw_ostream.h"
+#include <memory>
+
+using namespace mlir;
+using namespace mlir::neura;
+using namespace mlir::func;
+
+#define GEN_PASS_DEF_LOWERAFFINETONEURA
+#include "Conversion/ConversionPasses.h.inc"
+
+namespace {
+struct AffineLoadLowering : public OpRewritePattern<affine::AffineLoadOp> {
+  using OpRewritePattern<affine::AffineLoadOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(affine::AffineLoadOp loadOp,
+                                PatternRewriter &rewriter) const override {
+    auto loc = loadOp.getLoc();
+    auto memref = loadOp.getMemref();
+    AffineMap map = loadOp.getAffineMap();
+    ValueRange mapOperands = loadOp.getMapOperands();
+    // Get the indices for the load operation
+    SmallVector<Value, 4> newIndices;
+    newIndices.reserve(map.getNumResults());
+    llvm::errs() << "Lowering affine load operation: " << loadOp << "\n";
+    llvm::errs() << "Number of results in affine map: " << map.getNumResults()
+                 << "\n";
+    for (auto expr : map.getResults()) {
+      llvm::errs() << "Map expr: " << expr << "\n";
+    }
+
+    for (AffineExpr expr : map.getResults()) {
+      if (auto constExpr = expr.dyn_cast<AffineConstantExpr>()) {
+        auto indexType = rewriter.getIndexType();
+        auto valueAttr =
+            rewriter.getIntegerAttr(indexType, constExpr.getValue());
+        newIndices.push_back(rewriter.create<neura::ConstantOp>(
+            loc, indexType, valueAttr, nullptr));
+      } else if (auto dimExpr = expr.dyn_cast<AffineDimExpr>()) {
+        if (dimExpr.getPosition() >= map.getNumDims() ||
+            dimExpr.getPosition() >=
+                mapOperands
+                    .size()) { // Check against mapOperands size for safety
+          return loadOp.emitError(
+              "affine map dimension out of bounds for map operands");
+        }
+        newIndices.push_back(mapOperands[dimExpr.getPosition()]);
+      } else if (auto symExpr = expr.dyn_cast<AffineSymbolExpr>()) {
+        unsigned symbolOperandIndex = map.getNumDims() + symExpr.getPosition();
+        if (symbolOperandIndex >= mapOperands.size()) {
+          return loadOp.emitError(
+              "affine map symbol out of bounds for map operands");
+        }
+        newIndices.push_back(mapOperands[symbolOperandIndex]);
+      } else {
+        // For more complex affine expressions (e.g., d0 + c1),
+        // materialize the result using affine.apply.
+        // neura.load_indexed expects individual index values.
+        // This is a temporary workaround for complex expressions.
+        llvm::errs() << "Complex affine expression: " << expr << "\n";
+        AffineMap singleResultMap = AffineMap::get(
+            map.getNumDims(), map.getNumSymbols(), expr, rewriter.getContext());
+        Value complexIndex = rewriter.create<affine::AffineApplyOp>(
+            loc, singleResultMap, mapOperands);
+        newIndices.push_back(complexIndex);
+      }
+    }
+
+    auto memRefType = memref.getType().dyn_cast<MemRefType>();
+    if (!memRefType) {
+      return loadOp.emitError("base of load is not a MemRefType");
+    }
+    if (newIndices.size() != static_cast<size_t>(memRefType.getRank())) {
+      return loadOp.emitError("number of indices from affine map (")
+             << newIndices.size() << ") does not match memref rank ("
+             << memRefType.getRank() << ")";
+    }
+
+    // Create the neura.load_indexed operation
+    auto newLoadOp = rewriter.create<neura::LoadIndexedOp>(
+        loc, loadOp.getType(), memref, ValueRange{newIndices}, nullptr);
+
+    rewriter.replaceOp(loadOp, newLoadOp.getResult());
+    return success();
+  }
+};
+
+struct AffineStoreLowering : public OpRewritePattern<affine::AffineStoreOp> {
+  using OpRewritePattern<affine::AffineStoreOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(affine::AffineStoreOp storeOp,
+                                PatternRewriter &rewriter) const override {
+    auto loc = storeOp.getLoc();
+    auto memref = storeOp.getMemref();
+    auto value = storeOp.getValueToStore();
+    AffineMap map = storeOp.getAffineMap();
+    ValueRange mapOperands = storeOp.getMapOperands();
+
+    SmallVector<Value, 4> newIndices;
+    newIndices.reserve(map.getNumResults());
+
+    for (AffineExpr expr : map.getResults()) {
+      if (auto constExpr = expr.dyn_cast<AffineConstantExpr>()) {
+        auto indexType = rewriter.getIndexType();
+        auto valueAttr =
+            rewriter.getIntegerAttr(indexType, constExpr.getValue());
+        newIndices.push_back(rewriter.create<neura::ConstantOp>(
+            loc, indexType, valueAttr, nullptr));
+      } else if (auto dimExpr = expr.dyn_cast<AffineDimExpr>()) {
+        if (dimExpr.getPosition() >= map.getNumDims() ||
+            dimExpr.getPosition() >= mapOperands.size()) {
+          return storeOp.emitError(
+              "affine map dimension out of bounds for map operands");
+        }
+        newIndices.push_back(mapOperands[dimExpr.getPosition()]);
+      } else if (auto symExpr = expr.dyn_cast<AffineSymbolExpr>()) {
+        unsigned symbolOperandIndex = map.getNumDims() + symExpr.getPosition();
+        if (symbolOperandIndex >= mapOperands.size()) {
+          return storeOp.emitError(
+              "affine map symbol out of bounds for map operands");
+        }
+        newIndices.push_back(mapOperands[symbolOperandIndex]);
+      } else {
+        // For more complex affine expressions, materialize the result using
+        // affine.apply. This is a temporary workaround for complex expressions.
+        AffineMap singleResultMap = AffineMap::get(
+            map.getNumDims(), map.getNumSymbols(), expr, rewriter.getContext());
+        Value complexIndex = rewriter.create<affine::AffineApplyOp>(
+            loc, singleResultMap, mapOperands);
+        newIndices.push_back(complexIndex);
+      }
+    }
+
+    auto memRefType = memref.getType().dyn_cast<MemRefType>();
+    if (!memRefType) {
+      return storeOp.emitError("base of store is not a MemRefType");
+    }
+    if (newIndices.size() != static_cast<size_t>(memRefType.getRank())) {
+      return storeOp.emitError("number of indices from affine map (")
+             << newIndices.size() << ") does not match memref rank ("
+             << memRefType.getRank() << ")";
+    }
+
+    rewriter.create<neura::StoreIndexedOp>(loc, value, memref,
+                                           ValueRange{newIndices}, nullptr);
+    rewriter.eraseOp(storeOp);
+    return success();
+  }
+};
+
+struct AffineForLowering : public OpRewritePattern<affine::AffineForOp> {
+  using OpRewritePattern<affine::AffineForOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(affine::AffineForOp forOp,
+                                PatternRewriter &rewriter) const override {
+    auto loc = forOp.getLoc();
+    auto indexType = rewriter.getIndexType();
+
+    // 1. Extract loop parameters (lower bound, upper bound, step)
+    Value lowerBoundVal;
+    if (forOp.hasConstantLowerBound()) {
+      int lowerBoundConstant = forOp.getConstantLowerBound();
+      auto lowerBoundAttr =
+          rewriter.getIntegerAttr(indexType, lowerBoundConstant);
+      lowerBoundVal = rewriter.create<neura::ConstantOp>(
+          loc, indexType, lowerBoundAttr, nullptr);
+    } else {
+      // If the lower bound is not constant, we need to use affine.apply
+      // This is a temporary workaround for non-constant lower bounds.
+      llvm::errs() << "Using affine.apply for unconstant lower bound\n";
+      affine::AffineBound lowerBound = forOp.getLowerBound();
+      AffineMap lowerBoundMap = lowerBound.getMap();
+      ValueRange lowerBoundOperands = forOp.getLowerBoundOperands();
+      lowerBoundVal = rewriter.create<affine::AffineApplyOp>(
+          loc, lowerBoundMap, lowerBoundOperands);
+    }
+
+    Value upperBoundVal;
+    if (forOp.hasConstantUpperBound()) {
+      int upperBoundConstant = forOp.getConstantUpperBound();
+      auto upperBoundAttr =
+          rewriter.getIntegerAttr(indexType, upperBoundConstant);
+      upperBoundVal = rewriter.create<neura::ConstantOp>(
+          loc, indexType, upperBoundAttr, nullptr);
+    } else {
+      // For non-constant upper bounds, we also use affine.apply
+      llvm::errs() << "Using affine.apply for unconstant upper bound\n";
+      affine::AffineBound upperBound = forOp.getUpperBound();
+      AffineMap upperBoundMap = upperBound.getMap();
+      ValueRange upperBoundOperands = forOp.getUpperBoundOperands();
+      upperBoundVal = rewriter.create<affine::AffineApplyOp>(
+          loc, upperBoundMap, upperBoundOperands);
+    }
+
+    auto stepAttr = rewriter.getIntegerAttr(indexType, forOp.getStep());
+    Value stepVal =
+        rewriter.create<neura::ConstantOp>(loc, indexType, stepAttr, nullptr);
+    llvm::errs() << "lower bound: " << lowerBoundVal
+                 << ", upper bound: " << upperBoundVal << ", step: " << stepVal
+                 << "\n";
+
+    // 2. Block structure
+    Block *originBlock = rewriter.getInsertionBlock();
+    auto originPoint = rewriter.getInsertionPoint();
+    Region *parentRegion = originBlock->getParent();
+
+    Block *headerBlock = rewriter.createBlock(
+        parentRegion, std::next(Region::iterator(originBlock)), {indexType},
+        {loc});
+    Block *bodyBlock = rewriter.createBlock(
+        parentRegion, std::next(Region::iterator(headerBlock)), {indexType},
+        {loc});
+    Block *exitBlock = rewriter.createBlock(
+        parentRegion, std::next(Region::iterator(bodyBlock)));
+    Block *continueBlock = rewriter.splitBlock(originBlock, originPoint);
+
+    // 3. origin -> header
+    rewriter.setInsertionPointToEnd(originBlock);
+    rewriter.create<neura::Br>(loc, ValueRange{lowerBoundVal}, headerBlock);
+
+    // 4. header: loop_control
+    rewriter.setInsertionPointToEnd(headerBlock);
+    rewriter.create<neura::LoopControlOp>(
+        loc,
+        headerBlock->getArgument(0), // current index
+        stepVal, upperBoundVal, rewriter.getStringAttr("lt"),
+        ValueRange{}, // passthrough
+        bodyBlock, exitBlock);
+
+    // 5. body: clone forOp body, mapping index
+    rewriter.setInsertionPointToStart(bodyBlock);
+    Value currentIndex = bodyBlock->getArgument(0);
+    if (!forOp.getRegion().empty()) {
+      Block &sourceBlock = forOp.getRegion().front();
+      IRMapping mapping;
+      mapping.map(sourceBlock.getArgument(0), currentIndex);
+      for (auto &op : llvm::make_range(sourceBlock.begin(),
+                                       std::prev(sourceBlock.end()))) {
+        Operation *clonedOp = rewriter.clone(op, mapping);
+        for (unsigned i = 0; i < op.getNumResults(); ++i)
+          mapping.map(op.getResult(i), clonedOp->getResult(i));
+      }
+    }
+
+    // 6. body 结尾跳 header，传当前 index
+    rewriter.setInsertionPointToEnd(bodyBlock);
+    rewriter.create<neura::Br>(loc, ValueRange{currentIndex}, headerBlock);
+
+    // 7. exit 跳 continue
+    rewriter.setInsertionPointToEnd(exitBlock);
+    rewriter.create<neura::Br>(loc, ValueRange{}, continueBlock);
+
+    // 8. 移除原 affine.for
+    rewriter.eraseOp(forOp);
+
+    return success();
+  }
+};
+
+struct LowerAffineToNeuraPass
+    : public PassWrapper<LowerAffineToNeuraPass, OperationPass<func::FuncOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(LowerAffineToNeuraPass)
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<neura::NeuraDialect, arith::ArithDialect,
+                    memref::MemRefDialect, affine::AffineDialect>();
+  }
+
+  StringRef getArgument() const override { return "lower-affine-to-neura"; }
+  StringRef getDescription() const override {
+    return "Lower affine operations to Neura dialect operations";
+  }
+
+  void runOnOperation() override {
+    FuncOp funcOp = getOperation();
+    MLIRContext *context = funcOp.getContext();
+
+    // ConversionTarget target(*context);
+    // target.addIllegalOp<affine::AffineLoadOp, affine::AffineStoreOp, affine::AffineForOp>();
+    // target.addLegalDialect<neura::NeuraDialect, arith::ArithDialect,
+    //                        memref::MemRefDialect, affine::AffineDialect,
+    //                        func::FuncDialect>();
+
+    RewritePatternSet patterns(context);
+    patterns.add<AffineLoadLowering, AffineStoreLowering, AffineForLowering>(
+        context);
+
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                      std::move(patterns)))) {
+      funcOp.emitError("Failed to lower affine operations to Neura dialect");
+      signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<mlir::Pass> mlir::createLowerAffineToNeuraPass() {
+  return std::make_unique<LowerAffineToNeuraPass>();
+}

--- a/lib/Conversion/AffineToNeura/CMakeLists.txt
+++ b/lib/Conversion/AffineToNeura/CMakeLists.txt
@@ -1,0 +1,15 @@
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+add_mlir_conversion_library(MLIRNeuraAffineToNeuraPass
+  AffineToNeuraPass.cpp
+
+  DEPENDS
+  MLIRConversionIncGen
+
+  LINK_LIBS PUBLIC
+    MLIRIR
+    MLIRPass
+    MLIRSupport
+    MLIRTransforms
+    # MLIRNeura
+)

--- a/lib/Conversion/ArithToNeura/ArithToNeuraPass.cpp
+++ b/lib/Conversion/ArithToNeura/ArithToNeuraPass.cpp
@@ -24,7 +24,7 @@ using namespace mlir::func;
 using namespace mlir::neura;
 
 #define GEN_PASS_DEF_LOWERARITHTONEURA
-#include "NeuraDialect/NeuraPasses.h.inc"
+#include "Conversion/ConversionPasses.h.inc"
 
 namespace{
 

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -2,6 +2,7 @@ get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 add_subdirectory(ArithToNeura)
 add_subdirectory(LlvmToNeura)
+add_subdirectory(AffineToNeura)
 
 # add_mlir_library(
 #     MLIRNeuraConversion

--- a/lib/Conversion/LlvmToNeura/LlvmToNeuraPass.cpp
+++ b/lib/Conversion/LlvmToNeura/LlvmToNeuraPass.cpp
@@ -25,7 +25,7 @@ using namespace mlir;
 using namespace mlir::neura;
 
 #define GEN_PASS_DEF_LOWERLLVMTONEURA
-#include "NeuraDialect/NeuraPasses.h.inc"
+#include "Conversion/ConversionPasses.h.inc"
 
 
 namespace {

--- a/test/affine2neura/gpt2-node11/compile.sh
+++ b/test/affine2neura/gpt2-node11/compile.sh
@@ -1,0 +1,3 @@
+/home/lucas/Project/NeuraCompiler/thirdparty/Polygeist/build/bin/cgeist ./node11.cpp -S --raise-scf-to-affine -o ./node11.mlir
+/home/lucas/Project/NeuraCompiler/thirdparty/Polygeist/build/bin/polygeist-opt ./node11.mlir --affine-loop-unroll="unroll-factor=2" -o ./node11_unroll.mlir
+# /home/lucas/Project/NeuraCompiler/thirdparty/Polygeist/build/bin/polygeist-opt ./node27_unroll.mlir --affine-loop-tile="tile-size=2" -o ./node27_tile.mlir

--- a/test/affine2neura/gpt2-node11/node11.cpp
+++ b/test/affine2neura/gpt2-node11/node11.cpp
@@ -1,0 +1,12 @@
+float input[1][16][64];
+float output[1][16];
+
+int main() {
+  for (int arg2 = 0; arg2 < 1; arg2++) {
+    for (int arg3 = 0; arg3 < 16; arg3++) {
+      for (int arg4 = 0; arg4 < 64; arg4+=1) {
+        output[arg2][arg3] += input[arg2][arg3][arg4];
+      }
+    }
+  }
+}

--- a/test/affine2neura/gpt2-node27/compile.sh
+++ b/test/affine2neura/gpt2-node27/compile.sh
@@ -1,0 +1,3 @@
+/home/lucas/Project/NeuraCompiler/thirdparty/Polygeist/build/bin/cgeist ./node27_unroll.cpp -S --raise-scf-to-affine -o ./node27.mlir
+/home/lucas/Project/NeuraCompiler/thirdparty/Polygeist/build/bin/polygeist-opt ./node27.mlir --affine-loop-unroll="unroll-factor=2" -o ./node27_unroll.mlir
+# /home/lucas/Project/NeuraCompiler/thirdparty/Polygeist/build/bin/polygeist-opt ./node27_unroll.mlir --affine-loop-tile="tile-size=2" -o ./node27_tile.mlir

--- a/test/affine2neura/gpt2-node27/node27.cpp
+++ b/test/affine2neura/gpt2-node27/node27.cpp
@@ -1,0 +1,14 @@
+float input[1][16][4][16];
+float output[1][4][16][16];
+
+int main() {
+  for (int arg2 = 0; arg2 < 1; arg2++) {
+    for (int arg3 = 0; arg3 < 16; arg3++) {
+      for (int arg4 = 0; arg4 < 4; arg4 += 1) {
+        for (int arg5 = 0; arg5 < 16; arg5 += 1) {
+          output[arg2][arg3][arg4][arg5] = input[arg2][arg4][arg3][arg5];
+        }
+      }
+    }
+  }
+}

--- a/test/affine2neura/gpt2-node30/compile.sh
+++ b/test/affine2neura/gpt2-node30/compile.sh
@@ -1,0 +1,3 @@
+/home/lucas/Project/NeuraCompiler/thirdparty/Polygeist/build/bin/cgeist ./node30.cpp -S --raise-scf-to-affine -o ./node30.mlir
+/home/lucas/Project/NeuraCompiler/thirdparty/Polygeist/build/bin/polygeist-opt ./node30.mlir --affine-loop-unroll="unroll-factor=2" -o ./node30_unroll.mlir
+# /home/lucas/Project/NeuraCompiler/thirdparty/Polygeist/build/bin/polygeist-opt ./node27_unroll.mlir --affine-loop-tile="tile-size=2" -o ./node27_tile.mlir

--- a/test/affine2neura/gpt2-node30/node30.cpp
+++ b/test/affine2neura/gpt2-node30/node30.cpp
@@ -1,0 +1,15 @@
+float A[1][4][16][64];
+// float B=20.0;
+float C[1][4][16][64];
+
+int main() {
+  for (int arg2 = 0; arg2 < 1; arg2++) {
+    for (int arg3 = 0; arg3 < 4; arg3++) {
+      for (int arg4 = 0; arg4 < 16; arg4++) {
+        for (int arg5 = 0; arg5 < 64; arg5++) {
+          C[arg2][arg3][arg4][arg5] = A[arg2][arg3][arg4][arg5] * 10;
+        }
+      }
+    }
+  }
+}

--- a/test/affine2neura/simpleloop/compile.sh
+++ b/test/affine2neura/simpleloop/compile.sh
@@ -1,0 +1,3 @@
+/home/lucas/Project/NeuraCompiler/thirdparty/Polygeist/build/bin/cgeist ./simple.cpp -S --raise-scf-to-affine -o ./simple.mlir
+/home/lucas/Project/NeuraCompiler/thirdparty/Polygeist/build/bin/polygeist-opt ./simple.mlir --affine-loop-unroll="unroll-factor=2" -o ./simple_unroll.mlir
+# /home/lucas/Project/NeuraCompiler/thirdparty/Polygeist/build/bin/polygeist-opt ./node27_unroll.mlir --affine-loop-tile="tile-size=2" -o ./node27_tile.mlir

--- a/test/affine2neura/simpleloop/simple.cpp
+++ b/test/affine2neura/simpleloop/simple.cpp
@@ -1,0 +1,12 @@
+float A[100];
+float C[100];
+
+int main() {
+  const int size = 100;
+  for (int i = 0; i < size; ++i) {
+    float loaded_value = A[i];      // Instruction 1: Load value from A
+    float multiplied_value = loaded_value * 10.0f; // Instruction 2: Multiply the value
+    C[i] = multiplied_value;      // Instruction 3: Store result into C
+  }
+  return 0;
+}

--- a/tools/mlir-neura-opt/mlir-neura-opt.cpp
+++ b/tools/mlir-neura-opt/mlir-neura-opt.cpp
@@ -3,6 +3,7 @@
 #include "mlir/Dialect/DLTI/DLTI.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/InitAllDialects.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/InitAllPasses.h"
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/LogicalResult.h"
@@ -20,6 +21,8 @@ int main(int argc, char **argv) {
   registry.insert<mlir::arith::ArithDialect>();
   registry.insert<mlir::DLTIDialect>();
   registry.insert<mlir::LLVM::LLVMDialect>();
+  registry.insert<mlir::affine::AffineDialect>();
+  registry.insert<mlir::memref::MemRefDialect>();
 
   mlir::neura::registerPasses();
   mlir::registerPasses();


### PR DESCRIPTION
In this PR, the following tasks are finished:

1. Define 4 neura operations to support affine loops
- `neura.loop_iter`: Used for loop iteration organization, you can treat it like a combination of `phi-add-cmp` in llvm
- `neura.loop_control`: Used for loop iteration and control, you can treat it like a combination of `phi-add-cmp-br` in llvm
- `neura.load_indexed`: An operation used for fast array memory access, you can treat it like a combination of `gep-load` in llvm
- `neura.store_indexed`: An operation used for fast array memory access, you can treat it like a combination of `gep-store` in llvm
2. A pass that can lower some simple nested affine loops into neura dialect. Below is a simple example:
Source `Affine` mlir generated by Polygeist from `.cpp`
```
module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<!llvm.ptr<272>, dense<64> : vector<4xi32>>, #dlti.dl_entry<!llvm.ptr<271>, dense<32> : vector<4xi32>>, #dlti.dl_entry<i64, dense<64> : vector<2xi32>>, #dlti.dl_entry<!llvm.ptr<270>, dense<32> : vector<4xi32>>, #dlti.dl_entry<f80, dense<128> : vector<2xi32>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi32>>, #dlti.dl_entry<i1, dense<8> : vector<2xi32>>, #dlti.dl_entry<i8, dense<8> : vector<2xi32>>, #dlti.dl_entry<i16, dense<16> : vector<2xi32>>, #dlti.dl_entry<i32, dense<32> : vector<2xi32>>, #dlti.dl_entry<f16, dense<16> : vector<2xi32>>, #dlti.dl_entry<f64, dense<64> : vector<2xi32>>, #dlti.dl_entry<f128, dense<128> : vector<2xi32>>, #dlti.dl_entry<"dlti.endianness", "little">, #dlti.dl_entry<"dlti.stack_alignment", 128 : i32>>, llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", llvm.target_triple = "x86_64-unknown-linux-gnu", "polygeist.target-cpu" = "x86-64", "polygeist.target-features" = "+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87", "polygeist.tune-cpu" = "generic"} {
  memref.global @C : memref<100xf32> = uninitialized
  memref.global @A : memref<100xf32> = uninitialized
  func.func @main() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
    %cst = arith.constant 1.000000e+01 : f32
    %c0_i32 = arith.constant 0 : i32
    %0 = memref.get_global @A : memref<100xf32>
    %1 = memref.get_global @C : memref<100xf32>
    affine.for %arg0 = 0 to 100 {
      %2 = affine.load %0[%arg0] : memref<100xf32>
      %3 = arith.mulf %2, %cst : f32
      affine.store %3, %1[%arg0] : memref<100xf32>
    }
    return %c0_i32 : i32
  }
}
```
Lowered `Neura` mlir by applying this pass:
```
module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<!llvm.ptr<272>, dense<64> : vector<4xi32>>, #dlti.dl_entry<!llvm.ptr<271>, dense<32> : vector<4xi32>>, #dlti.dl_entry<i64, dense<64> : vector<2xi32>>, #dlti.dl_entry<!llvm.ptr<270>, dense<32> : vector<4xi32>>, #dlti.dl_entry<f80, dense<128> : vector<2xi32>>, #dlti.dl_entry<!llvm.ptr, dense<64> : vector<4xi32>>, #dlti.dl_entry<i1, dense<8> : vector<2xi32>>, #dlti.dl_entry<i8, dense<8> : vector<2xi32>>, #dlti.dl_entry<i16, dense<16> : vector<2xi32>>, #dlti.dl_entry<i32, dense<32> : vector<2xi32>>, #dlti.dl_entry<f16, dense<16> : vector<2xi32>>, #dlti.dl_entry<f64, dense<64> : vector<2xi32>>, #dlti.dl_entry<f128, dense<128> : vector<2xi32>>, #dlti.dl_entry<"dlti.endianness", "little">, #dlti.dl_entry<"dlti.stack_alignment", 128 : i32>>, llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", llvm.target_triple = "x86_64-unknown-linux-gnu", "polygeist.target-cpu" = "x86-64", "polygeist.target-features" = "+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87", "polygeist.tune-cpu" = "generic"} {
  memref.global @C : memref<100xf32> = uninitialized
  memref.global @A : memref<100xf32> = uninitialized
  func.func @main() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
    %cst = arith.constant 1.000000e+01 : f32
    %c0_i32 = arith.constant 0 : i32
    %0 = memref.get_global @A : memref<100xf32>
    %1 = memref.get_global @C : memref<100xf32>
    %2 = neura.constant {value = 0 : index} : index
    %3 = neura.constant {value = 100 : index} : index
    %4 = neura.constant {value = 1 : index} : index
    neura.br %2 : index to ^bb2
  ^bb1:  // pred: ^bb4
    return %c0_i32 : i32
  ^bb2(%5: index):  // 2 preds: ^bb0, ^bb3
    neura.loop_control current_index : %5, step : %4, bound : %3, loop_type : "lt" then ^bb3 else ^bb4
  ^bb3(%6: index):  // pred: ^bb2
    %7 = neura.load_indexed memref<100xf32> %0[%6] : f32
    %8 = arith.mulf %7, %cst : f32
    neura.store_indexed %8 to memref<100xf32> %1[%6] : f32
    neura.br %6 : index to ^bb2
  ^bb4:  // pred: ^bb2
    neura.br :  to ^bb1
  }
}
```

To Do:
- [ ] A neura compiler used for further development
- [ ] A DFG construction pass used in neura compiler
- [ ] A memory-aware mapping pass that fully utilizes the computation resources 