### PR TITLE
Raise the LLVM release to 20.1.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         git clone https://github.com/llvm/llvm-project.git
         cd llvm-project
-        git checkout cd70802
+        git checkout 6146a88
         mkdir build && cd build
         cmake -G Ninja ../llvm \
           -DLLVM_ENABLE_PROJECTS="mlir" \

--- a/lib/Conversion/ArithToNeura/ArithToNeuraPass.cpp
+++ b/lib/Conversion/ArithToNeura/ArithToNeuraPass.cpp
@@ -61,7 +61,7 @@ struct LowerArithToNeuraPass
     RewritePatternSet patterns(&getContext());
     mlir::neura::arith2neura::populateWithGenerated(patterns);
     patterns.add<ArithFAddToNeuraFAdd>(&getContext());
-    if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();
     }
   }

--- a/lib/Conversion/LlvmToNeura/LlvmToNeuraPass.cpp
+++ b/lib/Conversion/LlvmToNeura/LlvmToNeuraPass.cpp
@@ -328,7 +328,7 @@ struct LowerLlvmToNeuraPass
         auto target = func->getAttrOfType<StringAttr>(mlir::accel::kAcceleratorAttr);
         if (target && target.getValue() == mlir::accel::kNeuraTarget) {
           for (Region &region : func->getRegions()) {
-            if (failed(applyPatternsAndFoldGreedily(region, frozen))) {
+            if (failed(applyPatternsGreedily(region, frozen))) {
               signalPassFailure();
             }
           }

--- a/lib/NeuraDialect/Transforms/FusePatternsPass.cpp
+++ b/lib/NeuraDialect/Transforms/FusePatternsPass.cpp
@@ -115,7 +115,7 @@ struct FusePatternsPass : public PassWrapper<FusePatternsPass, OperationPass<Mod
     module_op.walk([&](Operation *op) {
       if (!op->getRegions().empty()) {
         for (Region &region : op->getRegions()) {
-          if (failed(applyPatternsAndFoldGreedily(region, frozen))) {
+          if (failed(applyPatternsGreedily(region, frozen))) {
             signalPassFailure();
           }
         }

--- a/lib/NeuraDialect/Transforms/InsertCtrlMovPass.cpp
+++ b/lib/NeuraDialect/Transforms/InsertCtrlMovPass.cpp
@@ -83,7 +83,7 @@ struct InsertCtrlMovPass
     module_op.walk([&](Operation *op) {
       if (!op->getRegions().empty()) {
         for (Region &region : op->getRegions()) {
-          if (failed(applyPatternsAndFoldGreedily(region, frozen))) {
+          if (failed(applyPatternsGreedily(region, frozen))) {
             signalPassFailure();
           }
         }

--- a/lib/NeuraDialect/Transforms/InsertDataMovPass.cpp
+++ b/lib/NeuraDialect/Transforms/InsertDataMovPass.cpp
@@ -90,7 +90,7 @@ struct InsertDataMovPass
     module_op.walk([&](Operation *op) {
       if (!op->getRegions().empty()) {
         for (Region &region : op->getRegions()) {
-          if (failed(applyPatternsAndFoldGreedily(region, frozen))) {
+          if (failed(applyPatternsGreedily(region, frozen))) {
             signalPassFailure();
           }
         }


### PR DESCRIPTION
Update the LLVM release to `20.1.7`.

In this release, the `applyPatternsAndFoldGreedily` is deprecated. We need to use `applyPatternsGreedily` instead.