### PR TITLE
Remove grant_always

### DIFF
--- a/include/NeuraDialect/NeuraOps.td
+++ b/include/NeuraDialect/NeuraOps.td
@@ -387,10 +387,11 @@ def Neura_LoopControllerOp : Op<NeuraDialect, "loop_controller">{
   }];
 
   let arguments = (ins
-    AnyType:$parent_valid,  // Valid predicate from the parent loop
+    AnyType:$parentValid,  // Valid predicate from the parent loop
     AnyType:$start,         // Start index of the loop
     AnyType:$end,           // End index of the loop
-    AnyType:$step           // Step size for the loop
+    AnyType:$step,           // Step size for the loop
+    StrAttr:$iterationType // Type of the loop iteration (e.g., "increment", "decrement")
   );
 
   let results = (outs
@@ -399,5 +400,5 @@ def Neura_LoopControllerOp : Op<NeuraDialect, "loop_controller">{
   );
 
   let assemblyFormat =
-    "$parent_valid `(` $start `,` $end `,` $step `)` attr-dict `:` type($parent_valid) `,` type($start) `,` type($end) `,` type($step) `->` type($index) `,` type($valid)";
+    " `(``parent_valid` `=` $parentValid `,` `start` `=` $start `,` `end` `=` $end `,` `step` `=` $step`)` attr-dict `:` type($parentValid) `,` type($start) `,` type($end) `,` type($step) `->` type($index) `,` type($valid)";
 }

--- a/lib/NeuraDialect/Transforms/FuseControlFlowPass.cpp
+++ b/lib/NeuraDialect/Transforms/FuseControlFlowPass.cpp
@@ -1,10 +1,19 @@
 #include "NeuraDialect/NeuraOps.h"
+#include "NeuraDialect/NeuraTypes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Attributes.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/LogicalResult.h"
+#include "llvm/Support/raw_ostream.h"
+#include <cassert>
+#include <cstddef>
+#include <memory>
 
 using namespace mlir;
 
@@ -16,43 +25,472 @@ namespace {
 class LoopInfo {
 public:
   // Key operations in a loop.
-  Value reserve_val;
-  Value phi_val;
-  Value index_val;
+  Value index_reserve_val; // Reserve values for index.
+  Value index_phi_val;
   Value condition_val;
   Value not_condition_val;
 
   // Loop iteration parameters.
-  Value start_val;
-  Value end_val;
-  Value step_val;
+  Value start_val; // Start value for the loop index.
+  Value end_val;   // End value for the loop index.
+  Value step_val;  // Step value for the loop index.
 
   // Backward edge information.
-  Operation *ctrl_mov = nullptr; // Initialized to nullptr.
+  Operation *index_ctrl_mov = nullptr; // Initialized to nullptr.
+  Operation *index_grant_op =
+      nullptr; // The grant_predicate operation for the index.
 
   // Used for replace and update operations.
   llvm::SetVector<Operation *> ops_to_remove;
   llvm::MapVector<Value, SmallVector<std::pair<Operation *, unsigned>>>
       users_to_update;
 
+  // Parent loop when handling nested loops, if any.
+  LoopInfo *parent_loop = nullptr;
+
   // Adds operations to remove.
   void addOpToRemove(Operation *op) {
     if (op) {
-      ops_to_remove.insert(op);
+      this->ops_to_remove.insert(op);
     }
   }
 
   // Checks if the loop info is complete.
   // There is no not_condition_val because it is derived from condition_val.
   bool isComplete() const {
-    return reserve_val && phi_val && index_val && condition_val && start_val &&
-           end_val && step_val && ctrl_mov;
+    return index_reserve_val && index_phi_val && condition_val && start_val &&
+           end_val && step_val && index_ctrl_mov;
   }
 
   // Records the users that use the loop index and (not-)condition values.
   void recordUsersToUpdate() {
-    // TODO: Implements the logic to record users of loop index and condition
-    // values.
+    recordUsersFor(this->index_phi_val);
+    recordUsersFor(this->index_reserve_val);
+    recordUsersFor(this->index_grant_op->getResult(0));
+    recordUsersFor(this->condition_val);
+    if (this->not_condition_val) {
+      recordUsersFor(this->not_condition_val);
+    }
+  }
+
+private:
+  // Records users of a value.
+  void recordUsersFor(Value val) {
+    if (!val) {
+      return;
+    }
+    for (OpOperand &use : val.getUses()) {
+      Operation *user = use.getOwner();
+      // Records the user that will not be removed.
+      if (!ops_to_remove.contains(user)) {
+        users_to_update[val].push_back({user, use.getOperandNumber()});
+      }
+    }
+  }
+};
+
+// Finds the original parameter for start value.
+Value findOriginalConstant(Value val,
+                           llvm::SetVector<Operation *> &ops_to_remove) {
+  if (!val || !val.getDefiningOp())
+    return val;
+
+  Operation *def_op = val.getDefiningOp();
+
+  // If the value is already a constant, return it.
+  if (auto const_op = dyn_cast<neura::ConstantOp>(def_op)) {
+    return val;
+  }
+
+  // Handle grant operations and add them to the removal list.
+  if (auto grant_once_op = dyn_cast<neura::GrantOnceOp>(def_op)) {
+    ops_to_remove.insert(def_op);
+    return findOriginalConstant(grant_once_op.getValue(), ops_to_remove);
+  }
+
+  if (auto grant_always_op = dyn_cast<neura::GrantAlwaysOp>(def_op)) {
+    ops_to_remove.insert(def_op);
+    return findOriginalConstant(grant_always_op.getValue(), ops_to_remove);
+  }
+
+  // For grant_predicate, only track value inputs and ignore condition inputs.
+  if (auto grant_predicate_op = dyn_cast<neura::GrantPredicateOp>(def_op)) {
+    ops_to_remove.insert(def_op);
+    return findOriginalConstant(grant_predicate_op.getValue(), ops_to_remove);
+  }
+
+  return val;
+}
+
+// Identifies a simple loop.
+// The pattern is: reserve -> phi -> icmp -> [not] -> grant_predicate ->
+// ctrl_mov <- add
+std::unique_ptr<LoopInfo> identifyLoop(Operation *index_reserve_op) {
+  if (!isa<neura::ReserveOp>(index_reserve_op)) {
+    return nullptr;
+  }
+
+  // Starts from the reserve operation.
+  auto loop = std::make_unique<LoopInfo>();
+  loop->index_reserve_val = index_reserve_op->getResult(0);
+  loop->addOpToRemove(index_reserve_op);
+
+  // Identifies the phi operation.
+  neura::PhiOp index_phi_op = nullptr;
+  for (Operation *user : loop->index_reserve_val.getUsers()) {
+    if (auto phi = dyn_cast<neura::PhiOp>(user)) {
+      index_phi_op = phi;
+      break;
+    }
+  }
+
+  if (!index_phi_op) {
+    llvm::errs()
+        << "[CtrlFlowFuse] No index phi operation found for the loop.\n";
+    return nullptr; // No phi operation found.
+  }
+
+  loop->index_phi_val = index_phi_op.getResult();
+  loop->addOpToRemove(index_phi_op);
+
+  // Finds the start value for loop index.
+  Value initial_value = nullptr;
+  for (Value input : index_phi_op.getInputs()) {
+    if (input != loop->index_reserve_val) {
+      initial_value = input;
+      break;
+    }
+  }
+
+  if (!initial_value) {
+    llvm::errs()
+        << "[CtrlFlowFuse] No initial value found for the loop index.\n";
+    return nullptr; // No start value found.
+  }
+
+  loop->start_val = findOriginalConstant(initial_value, loop->ops_to_remove);
+
+  // Identifies the phi->icmp->[not]->grant_predicate pattern.
+  for (Operation *phi_user : index_phi_op->getUsers()) {
+    if (neura::ICmpOp icmp_op = dyn_cast<neura::ICmpOp>(phi_user)) {
+      if (icmp_op.getCmpType() == "slt" &&
+          icmp_op.getLhs() == loop->index_phi_val) {
+        loop->condition_val = icmp_op.getResult();
+        loop->end_val = icmp_op.getRhs();
+        loop->addOpToRemove(icmp_op);
+
+        // Identifies the not operation if it exists.
+        for (Operation *cond_user : icmp_op->getUsers()) {
+          if (neura::NotOp not_op = dyn_cast<neura::NotOp>(cond_user)) {
+            loop->not_condition_val = not_op.getResult();
+            loop->addOpToRemove(not_op);
+            break;
+          }
+        }
+
+        // Identifies the grant_predicate operation for the index_phi_val.
+        for (Operation *cond_user : icmp_op->getUsers()) {
+          if (neura::GrantPredicateOp grant_predicate_op =
+                  dyn_cast<neura::GrantPredicateOp>(cond_user)) {
+            if (grant_predicate_op.getValue() == loop->index_phi_val &&
+                grant_predicate_op.getPredicate() == loop->condition_val) {
+              loop->index_grant_op = grant_predicate_op;
+              loop->addOpToRemove(grant_predicate_op);
+              break;
+            }
+          }
+        }
+        break;
+      } else {
+        // TODO: Adds support for other compare types if needed.
+        if (icmp_op.getCmpType() != "slt") {
+          llvm::errs() << "[CtrlFlowFuse] Unsupported compare type: "
+                       << icmp_op.getCmpType() << "\n";
+        } else {
+          llvm::errs() << "[CtrlFlowFuse] Loop condition does not match "
+                          "expected value.\n";
+        }
+        return nullptr; // Unsupported compare type.
+      }
+    }
+  }
+
+  if (!loop->condition_val || !loop->end_val || !loop->index_phi_val) {
+    llvm::errs() << "[CtrlFlowFuse] Incomplete loop information.\n";
+    return nullptr; // Incomplete loop.
+  }
+
+  // Identifies the ctrl_mov<-add pattern.
+  for (Operation *user : loop->index_reserve_val.getUsers()) {
+    if (neura::CtrlMovOp ctrl_mov_op = dyn_cast<neura::CtrlMovOp>(user)) {
+      if (ctrl_mov_op.getTarget() == loop->index_reserve_val) {
+        loop->index_ctrl_mov = ctrl_mov_op;
+        loop->addOpToRemove(ctrl_mov_op);
+
+        if (neura::AddOp add_op =
+                ctrl_mov_op.getValue().getDefiningOp<neura::AddOp>()) {
+          loop->addOpToRemove(add_op);
+          Value granted_index = loop->index_grant_op->getResult(0);
+          if (add_op.getLhs() == granted_index) {
+            loop->step_val =
+                findOriginalConstant(add_op.getRhs(), loop->ops_to_remove);
+          } else if (add_op.getRhs() == granted_index) {
+            loop->step_val =
+                findOriginalConstant(add_op.getLhs(), loop->ops_to_remove);
+          }
+        }
+        break;
+      }
+    }
+  }
+
+  if (!loop->index_ctrl_mov || !loop->step_val) {
+    llvm::errs() << "[CtrlFlowFuse] Incomplete loop information: ctrl_mov or "
+                    "step value not found.\n";
+    return nullptr; // Incomplete loop.
+  }
+
+  if (loop->isComplete()) {
+    loop->recordUsersToUpdate();
+    return loop;
+  }
+
+  return nullptr; // Incomplete loop.
+}
+
+Value createConstantPredicate(PatternRewriter &rewriter, Location loc,
+                              bool value) {
+  auto predicated_type = rewriter.getType<neura::PredicatedValue>(
+      rewriter.getI1Type(), rewriter.getI1Type());
+  return rewriter.create<neura::ConstantOp>(loc, predicated_type,
+                                            rewriter.getBoolAttr(value),
+                                            rewriter.getBoolAttr(true));
+}
+
+Value ensureCorrectType(PatternRewriter &rewriter, Location loc, Value value,
+                        Type target_type) {
+  if (!value || value.getType() == target_type) {
+    return value;
+  }
+  // If the types don't match, we need to cast the value.
+  // Predicate bit defaults to null.
+  // TODO: Handles cases where the cast is not trivial.
+  return rewriter.create<neura::CastOp>(
+      loc, target_type, value, rewriter.getStringAttr("unknown cast"), nullptr);
+}
+
+Operation *findDefiningOp(Value value) {
+  if (!value) {
+    return nullptr;
+  }
+  return value.getDefiningOp();
+}
+
+LogicalResult replaceWithLoopController(LoopInfo *loop_info,
+                                        PatternRewriter &rewriter) {
+  if (!loop_info || !loop_info->isComplete()) {
+    assert(false && "LoopInfo is incomplete or null.");
+    return failure();
+  }
+
+  Location loc = loop_info->index_reserve_val.getLoc();
+
+  Operation *start_def_op = findDefiningOp(loop_info->start_val);
+  Operation *end_def_op = findDefiningOp(loop_info->end_val);
+  Operation *step_def_op = findDefiningOp(loop_info->step_val);
+
+  // Gets the insertion point for the new loop_controller operation.
+  Operation *insertion_point = nullptr;
+
+  // Compares the defining operations to find the latest one.
+  auto updateLatestOp = [&](Operation *op1, Operation *op2) -> Operation * {
+    if (!op1)
+      return op2;
+    if (!op2)
+      return op1;
+    // Returns the later operation in the block.
+    return op2->isBeforeInBlock(op1) ? op1 : op2;
+  };
+
+  // Updates the insertion point based on the defining operations.
+  if (start_def_op) {
+    insertion_point = updateLatestOp(insertion_point, start_def_op);
+  }
+  if (end_def_op) {
+    insertion_point = updateLatestOp(insertion_point, end_def_op);
+  }
+  if (step_def_op) {
+    insertion_point = updateLatestOp(insertion_point, step_def_op);
+  }
+
+  // Sets the insertion point after the latest defining operation.
+  if (insertion_point) {
+    rewriter.setInsertionPointAfter(insertion_point);
+  } else {
+    assert(false && "No valid insertion point found for loop_controller");
+    return failure();
+  }
+
+  // Creates the parentValid signal for loop_controller.
+  auto true_val = createConstantPredicate(rewriter, loc, true);
+
+  // Prepares the values and iter type for loop_controller.
+  auto index_type = loop_info->index_phi_val.getType();
+  rewriter.setInsertionPointAfter(true_val.getDefiningOp());
+
+  Value start_val =
+      ensureCorrectType(rewriter, loc, loop_info->start_val, index_type);
+  Value end_val =
+      ensureCorrectType(rewriter, loc, loop_info->end_val, index_type);
+  Value step_val =
+      ensureCorrectType(rewriter, loc, loop_info->step_val, index_type);
+  StringAttr iter_type;
+  if (neura::ICmpOp icmp_op =
+          dyn_cast<neura::ICmpOp>(loop_info->condition_val.getDefiningOp())) {
+    if (icmp_op.getCmpType() == "slt") {
+      iter_type = rewriter.getStringAttr("increment");
+    } else {
+      assert(false && "Unsupported compare type");
+      return failure(); // Unsupported compare type.
+    }
+  }
+
+  // Creates the loop_controller operation.
+  auto loop_controller = rewriter.create<neura::LoopControllerOp>(
+      loc, index_type, true_val.getType(), true_val, start_val, end_val,
+      step_val, iter_type);
+
+  Value new_index = loop_controller.getIndex();
+  Value new_valid = loop_controller.getValid();
+
+  // Creates the replacement map for the loop info.
+  DenseMap<Value, Value> replacement_map;
+
+  // Creates the map for loop_info values (index_phi_val, condition_val, etc.)
+  replacement_map[loop_info->index_phi_val] = new_index;
+  if (loop_info->index_grant_op) {
+    replacement_map[loop_info->index_grant_op->getResult(0)] = new_index;
+  }
+  replacement_map[loop_info->condition_val] = new_valid;
+  neura::NotOp new_not;
+  if (loop_info->not_condition_val) {
+    rewriter.setInsertionPointAfter(loop_controller);
+    new_not = rewriter.create<neura::NotOp>(
+        loc, loop_info->not_condition_val.getType(), new_valid);
+    replacement_map[loop_info->not_condition_val] = new_not.getResult();
+  }
+
+  // Replaces the index_reserve_val with the new index.
+  if (!loop_info->users_to_update[loop_info->index_phi_val].empty()) {
+    for (auto &user_info :
+         loop_info->users_to_update[loop_info->index_phi_val]) {
+      Operation *user = user_info.first;
+      unsigned idx = user_info.second;
+      user->setOperand(idx, new_index);
+    }
+  }
+
+  // Replaces the granted index value with the new index.
+  if (loop_info->index_grant_op &&
+      !loop_info->users_to_update[loop_info->index_grant_op->getResult(0)]
+           .empty()) {
+    for (auto &user_info :
+         loop_info->users_to_update[loop_info->index_grant_op->getResult(0)]) {
+      Operation *user = user_info.first;
+      unsigned idx = user_info.second;
+      user->setOperand(idx, new_index);
+    }
+  }
+
+  // Replaces the condition_val with the new_valid value.
+  if (!loop_info->users_to_update[loop_info->condition_val].empty()) {
+    for (auto &user_info :
+         loop_info->users_to_update[loop_info->condition_val]) {
+      Operation *user = user_info.first;
+      unsigned idx = user_info.second;
+      user->setOperand(idx, new_valid);
+    }
+  }
+
+  // Handles not_condition_val if it exists
+  if (loop_info->not_condition_val &&
+      !loop_info->users_to_update[loop_info->not_condition_val].empty()) {
+    // Replaces all uses of not_condition_val with the result of new_not
+    for (auto &user_info :
+         loop_info->users_to_update[loop_info->not_condition_val]) {
+      Operation *user = user_info.first;
+      unsigned idx = user_info.second;
+      user->setOperand(idx, new_not.getResult());
+    }
+  }
+
+  // Replaces the internal uses of the old loop info values.
+  for (Operation *op : loop_info->ops_to_remove) {
+    for (OpOperand &operand : op->getOpOperands()) {
+      Value old_val = operand.get();
+      if (replacement_map.count(old_val)) {
+        operand.set(replacement_map[old_val]);
+      }
+    }
+  }
+
+  // Tracks erased operations.
+  llvm::SmallPtrSet<Operation *, 16> erased_ops;
+  bool made_progress = true;
+  while (made_progress) {
+    made_progress = false;
+    for (Operation *op : loop_info->ops_to_remove) {
+      if (!erased_ops.contains(op) && op->use_empty()) {
+        rewriter.eraseOp(op);
+        erased_ops.insert(op);
+        made_progress = true;
+      }
+    }
+  }
+
+  // Checks if all operations were removed.
+  for (Operation *op : loop_info->ops_to_remove) {
+    if (!erased_ops.contains(op)) {
+      llvm::errs() << "Warning: Could not remove operation: " << *op << "\n";
+      llvm::errs() << "  Users: ";
+      for (Value result : op->getResults()) {
+        for (Operation *user : result.getUsers()) {
+          llvm::errs() << *user << " ";
+        }
+      }
+      llvm::errs() << "\n";
+    }
+  }
+
+  return success();
+}
+
+struct FuseLoopControlFlowPattern : public OpRewritePattern<func::FuncOp> {
+  using OpRewritePattern<func::FuncOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(func::FuncOp func_op,
+                                PatternRewriter &rewriter) const override {
+    // Saves all the identified loops.
+    std::vector<std::unique_ptr<LoopInfo>> identified_loops;
+
+    // Step 1: Identify loops in the function.
+    func_op.walk([&](neura::ReserveOp reserveOp) {
+      if (auto loop = identifyLoop(reserveOp)) {
+        identified_loops.push_back(std::move(loop));
+      }
+    });
+
+    if (identified_loops.empty()) {
+      return failure();
+    }
+
+    for (auto &loop_info : identified_loops) {
+      if (failed(replaceWithLoopController(loop_info.get(), rewriter))) {
+        return failure();
+      }
+    }
+
+    return success();
   }
 };
 
@@ -68,7 +506,13 @@ struct FuseControlFlowPass
 
   void runOnOperation() override {
     ModuleOp module_op = getOperation();
-    // TODO: Adds the logic to fuse determined control flow operations.
+    RewritePatternSet patterns(&getContext());
+
+    patterns.add<FuseLoopControlFlowPattern>(&getContext());
+
+    if (failed(applyPatternsGreedily(module_op, std::move(patterns)))) {
+      signalPassFailure();
+    }
   }
 };
 } // namespace

--- a/lib/NeuraDialect/Transforms/TransformCtrlToDataFlowPass.cpp
+++ b/lib/NeuraDialect/Transforms/TransformCtrlToDataFlowPass.cpp
@@ -36,30 +36,34 @@ void GrantPredicateInEntryBlock(Block *entry_block, OpBuilder &builder) {
   // Step 1: Collects all live-out values first.
   for (Operation &op : *entry_block) {
     for (Value result : op.getResults()) {
-      if (!isa<neura::PredicatedValue>(result.getType()))
+      if (!isa<neura::PredicatedValue>(result.getType())) {
         continue;
+      }
 
       bool used_in_branch = false;
-      bool used_elsewhere = false;
 
       for (OpOperand &use : result.getUses()) {
         Operation *user = use.getOwner();
 
         // Case 1: Operand of a branch/cond_br → grant_once
+        // Since we add the --cononicalize-live-in pass, all the live-out values
+        // in entry block must be passed to other blocks using branch/cond_br.
         if (isa<neura::Br, neura::CondBr>(user)) {
           used_in_branch = true;
         }
 
-        // Case 2: Used directly in other blocks → grant_always
-        if (user->getBlock() != entry_block) {
-          used_elsewhere = true;
+        if (!isa<neura::Br, neura::CondBr>(user) &&
+            user->getBlock() != entry_block) {
+          assert(
+              false &&
+              "Live-out value in entry block must be used in a branch/cond_br "
+              "operation.");
         }
       }
 
-      if (used_in_branch)
+      if (used_in_branch) {
         live_out_arg_values.push_back(result);
-      if (used_elsewhere)
-        live_out_non_arg_values.push_back(result);
+      }
     }
   }
 
@@ -78,26 +82,6 @@ void GrantPredicateInEntryBlock(Block *entry_block, OpBuilder &builder) {
     for (OpOperand &use : llvm::make_early_inc_range(val.getUses())) {
       Operation *user = use.getOwner();
       if (isa<neura::Br, neura::CondBr>(user)) {
-        use.set(granted.getResult());
-      }
-    }
-  }
-
-  // Inserts grant_always.
-  for (Value val : live_out_non_arg_values) {
-    Operation *def_op = val.getDefiningOp();
-    if (!def_op)
-      continue;
-
-    builder.setInsertionPointAfter(def_op);
-    auto granted = builder.create<neura::GrantAlwaysOp>(def_op->getLoc(),
-                                                        val.getType(), val);
-
-    // Replaces direct external uses (not in entry block, not in branch ops).
-    for (OpOperand &use : llvm::make_early_inc_range(val.getUses())) {
-      Operation *user = use.getOwner();
-      if (user->getBlock() != entry_block &&
-          !isa<neura::Br, neura::CondBr>(user)) {
         use.set(granted.getResult());
       }
     }

--- a/test/affine2neura/bert/bert_node1/bert_node1.mlir
+++ b/test/affine2neura/bert/bert_node1/bert_node1.mlir
@@ -1,6 +1,23 @@
 // RUN: mlir-opt %s --lower-affine --convert-scf-to-cf --convert-cf-to-llvm -o %t-llvm.mlir
-// RUN: mlir-neura-opt %t-llvm.mlir --assign-accelerator --lower-arith-to-neura --lower-memref-to-neura --lower-builtin-to-neura --lower-llvm-to-neura | FileCheck %s
-// RUN: mlir-neura-opt %t-llvm.mlir --assign-accelerator --lower-arith-to-neura --lower-memref-to-neura --lower-builtin-to-neura --lower-llvm-to-neura --leverage-predicated-value --transform-ctrl-to-data-flow | FileCheck %s -check-prefix=CTRL2DATA
+// RUN: mlir-neura-opt %t-llvm.mlir \
+// RUN: --assign-accelerator \
+// RUN: --lower-arith-to-neura \
+// RUN: --lower-memref-to-neura \
+// RUN: --lower-builtin-to-neura \
+// RUN: --lower-llvm-to-neura \
+// RUN: | FileCheck %s
+
+// RUN: mlir-neura-opt %t-llvm.mlir \
+// RUN: --assign-accelerator \
+// RUN: --lower-arith-to-neura \
+// RUN: --lower-memref-to-neura \
+// RUN: --lower-builtin-to-neura \
+// RUN: --lower-llvm-to-neura \
+// RUN: --canonicalize-cast \
+// RUN: --canonicalize-live-in \
+// RUN: --leverage-predicated-value \
+// RUN: --transform-ctrl-to-data-flow \
+// RUN: | FileCheck %s -check-prefix=CTRL2DATA
 module attributes {} {
   func.func @_Z10bert_node1PA1_A1_A1_A1_A128_bPA1_A128_S1_(%arg0: memref<?x1x1x1x1x128xi8>, %arg1: memref<?x1x128x1x1x128xi8>) attributes {} {
     affine.for %arg2 = 0 to 128 {
@@ -46,39 +63,46 @@ module attributes {} {
 
 
 // CTRL2DATA: func.func @_Z10bert_node1PA1_A1_A1_A1_A128_bPA1_A128_S1_(%arg0: memref<?x1x1x1x1x128xi8>, %arg1: memref<?x1x128x1x1x128xi8>) attributes {accelerator = "neura"} {
-// CTRL2DATA-NEXT:     %0 = "neura.constant"() <{predicate = true, value = 1 : index}> : () -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %1 = "neura.grant_always"(%0) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 128 : index}> : () -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %3 = "neura.grant_always"(%2) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %4 = "neura.constant"() <{predicate = true, value = 0 : index}> : () -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %5 = "neura.grant_always"(%4) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %6 = "neura.cast"(%4) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %1 = "neura.grant_once"(%0) : (!neura.data<memref<?x1x1x1x1x128xi8>, i1>) -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %2 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %3 = "neura.grant_once"(%2) : (!neura.data<memref<?x1x128x1x1x128xi8>, i1>) -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %4 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %5 = "neura.grant_once"(%4) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %6 = "neura.constant"() <{predicate = true, value = 128 : i64}> : () -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %7 = "neura.grant_once"(%6) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %8 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %9 = "neura.phi"(%8, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %10 = "neura.cast"(%9) <{cast_type = "int_to_index"}> : (!neura.data<i64, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %11 = "neura.icmp"(%10, %3) <{cmpType = "slt"}> : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %12 = "neura.not"(%11) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %13 = neura.grant_predicate %5, %11 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %14 = "neura.cast"(%13) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %15 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %16 = "neura.phi"(%15, %14) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %17 = "neura.cast"(%16) <{cast_type = "int_to_index"}> : (!neura.data<i64, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %18 = "neura.icmp"(%17, %3) <{cmpType = "slt"}> : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %19 = "neura.not"(%18) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %20 = neura.grant_predicate %5, %18 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %21 = neura.grant_predicate %17, %18 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %22 = neura.load_indexed %arg0[%20, %20, %20, %20, %20, %21 : !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>] memref<?x1x1x1x1x128xi8> : !neura.data<i8, i1>
-// CTRL2DATA-NEXT:     %23 = neura.grant_predicate %10, %18 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %22 to %arg1[%20, %20, %23, %20, %20, %21 : !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>] memref<?x1x128x1x1x128xi8> : !neura.data<i8, i1>
-// CTRL2DATA-NEXT:     %24 = neura.grant_predicate %1, %18 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %25 = "neura.add"(%21, %24) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %26 = "neura.cast"(%25) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %26 -> %15 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %27 = neura.grant_predicate %10, %19 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %28 = neura.grant_predicate %1, %19 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %29 = "neura.add"(%27, %28) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %30 = "neura.cast"(%29) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %30 -> %8 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %8 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %9 = "neura.grant_once"(%8) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %10 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %11 = "neura.phi"(%10, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %12 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %13 = "neura.phi"(%12, %9) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %14 = "neura.icmp"(%13, %11) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %15 = "neura.not"(%14) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %16 = neura.grant_predicate %9, %14 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %17 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %18 = "neura.phi"(%17, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %19 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %20 = "neura.phi"(%19, %16) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %21 = "neura.icmp"(%20, %18) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %22 = neura.grant_predicate %1, %21 : !neura.data<memref<?x1x1x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %23 = neura.grant_predicate %9, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %24 = neura.grant_predicate %20, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %25 = neura.grant_predicate %3, %21 : !neura.data<memref<?x1x128x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %13, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %27 = neura.grant_predicate %5, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %28 = neura.grant_predicate %7, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %29 = "neura.not"(%21) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %30 = neura.grant_predicate %13, %29 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %31 = neura.grant_predicate %5, %29 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %32 = neura.grant_predicate %7, %29 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %33 = neura.load_indexed %22[%23, %23, %23, %23, %23, %24 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x1x1x1x1x128xi8>, i1> : !neura.data<i8, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %33 to %25[%23, %23, %26, %23, %23, %24 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x1x128x1x1x128xi8>, i1> : !neura.data<i8, i1>
+// CTRL2DATA-NEXT:     %34 = "neura.add"(%24, %27) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %34 -> %19 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %28 -> %17 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %35 = "neura.add"(%30, %31) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %35 -> %12 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %32 -> %10 : !neura.data<i64, i1> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     "neura.return"() : () -> ()
 // CTRL2DATA-NEXT:   }

--- a/test/affine2neura/bert/bert_node28/bert_node28.mlir
+++ b/test/affine2neura/bert/bert_node28/bert_node28.mlir
@@ -1,6 +1,23 @@
 // RUN: mlir-opt %s --lower-affine --convert-scf-to-cf --convert-cf-to-llvm -o %t-llvm.mlir
-// RUN: mlir-neura-opt %t-llvm.mlir --assign-accelerator --lower-arith-to-neura --lower-memref-to-neura --lower-builtin-to-neura --lower-llvm-to-neura | FileCheck %s
-// RUN: mlir-neura-opt %t-llvm.mlir --assign-accelerator --lower-arith-to-neura --lower-memref-to-neura --lower-builtin-to-neura --lower-llvm-to-neura --leverage-predicated-value --transform-ctrl-to-data-flow | FileCheck %s -check-prefix=CTRL2DATA
+// RUN: mlir-neura-opt %t-llvm.mlir \
+// RUN: --assign-accelerator \
+// RUN: --lower-arith-to-neura \
+// RUN: --lower-memref-to-neura \
+// RUN: --lower-builtin-to-neura \
+// RUN: --lower-llvm-to-neura \
+// RUN: | FileCheck %s
+
+// RUN: mlir-neura-opt %t-llvm.mlir \
+// RUN: --assign-accelerator \
+// RUN: --lower-arith-to-neura \
+// RUN: --lower-memref-to-neura \
+// RUN: --lower-builtin-to-neura \
+// RUN: --lower-llvm-to-neura \
+// RUN: --canonicalize-cast \
+// RUN: --canonicalize-live-in \
+// RUN: --leverage-predicated-value \
+// RUN: --transform-ctrl-to-data-flow \
+// RUN: | FileCheck %s -check-prefix=CTRL2DATA
 module attributes {} {
   func.func @_Z11bert_node28PA128_A768_KfPA768_S0_PA128_A768_f(%arg0: memref<?x128x768xf32>, %arg1: memref<?x768x768xf32>, %arg2: memref<?x128x768xf32>) attributes {} {
     affine.for %arg3 = 0 to 128 {
@@ -65,59 +82,70 @@ module attributes {} {
 // CHECK-NEXT: "neura.return"() : () -> ()
 
 
-// CTRL2DATA: func.func @_Z11bert_node28PA128_A768_KfPA768_S0_PA128_A768_f(%arg0: memref<?x128x768xf32>, %arg1: memref<?x768x768xf32>, %arg2: memref<?x128x768xf32>) attributes {accelerator = "neura"} {
-// CTRL2DATA-NEXT: %0 = "neura.constant"() <{predicate = true, value = 768 : index}> : () -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %1 = "neura.grant_always"(%0) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %2 = "neura.constant"() <{predicate = true, value = 1 : index}> : () -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %3 = "neura.grant_always"(%2) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %4 = "neura.constant"() <{predicate = true, value = 128 : index}> : () -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %5 = "neura.grant_always"(%4) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %6 = "neura.constant"() <{predicate = true, value = 0 : index}> : () -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %7 = "neura.grant_always"(%6) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %8 = "neura.cast"(%6) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT: %9 = "neura.grant_once"(%8) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT: %10 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT: %11 = "neura.phi"(%10, %9) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT: %12 = "neura.cast"(%11) <{cast_type = "int_to_index"}> : (!neura.data<i64, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %13 = "neura.icmp"(%12, %5) <{cmpType = "slt"}> : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT: %14 = "neura.not"(%13) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT: %15 = neura.grant_predicate %7, %13 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %16 = "neura.cast"(%15) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT: %17 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT: %18 = "neura.phi"(%17, %16) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT: %19 = "neura.cast"(%18) <{cast_type = "int_to_index"}> : (!neura.data<i64, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %20 = "neura.icmp"(%19, %1) <{cmpType = "slt"}> : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT: %21 = "neura.not"(%20) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT: %22 = neura.grant_predicate %7, %20 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %23 = "neura.cast"(%22) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT: %24 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT: %25 = "neura.phi"(%24, %23) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT: %26 = "neura.cast"(%25) <{cast_type = "int_to_index"}> : (!neura.data<i64, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %27 = "neura.icmp"(%26, %1) <{cmpType = "slt"}> : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT: %28 = "neura.not"(%27) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT: %29 = neura.grant_predicate %7, %27 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %30 = neura.grant_predicate %12, %27 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %31 = neura.grant_predicate %26, %27 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %32 = neura.load_indexed %arg0[%29, %30, %31 : !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>] memref<?x128x768xf32> : !neura.data<f32, i1>
-// CTRL2DATA-NEXT: %33 = neura.grant_predicate %19, %27 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %34 = neura.load_indexed %arg1[%29, %31, %33 : !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>] memref<?x768x768xf32> : !neura.data<f32, i1>
-// CTRL2DATA-NEXT: %35 = neura.load_indexed %arg2[%29, %30, %33 : !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>] memref<?x128x768xf32> : !neura.data<f32, i1>
-// CTRL2DATA-NEXT: %36 = "neura.fmul"(%32, %34) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT: %37 = "neura.fadd"(%35, %36) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT: neura.store_indexed %37 to %arg2[%29, %30, %33 : !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>] memref<?x128x768xf32> : !neura.data<f32, i1>
-// CTRL2DATA-NEXT: %38 = neura.grant_predicate %3, %27 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %39 = "neura.add"(%31, %38) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %40 = "neura.cast"(%39) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT: neura.ctrl_mov %40 -> %24 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT: %41 = neura.grant_predicate %19, %28 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %42 = neura.grant_predicate %3, %28 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %43 = "neura.add"(%41, %42) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %44 = "neura.cast"(%43) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT: neura.ctrl_mov %44 -> %17 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT: %45 = neura.grant_predicate %12, %21 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %46 = neura.grant_predicate %3, %21 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %47 = "neura.add"(%45, %46) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT: %48 = "neura.cast"(%47) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT: neura.ctrl_mov %48 -> %10 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT: "neura.return"() : () -> ()
-// CTRL2DATA-NEXT: }
+// CTRL2DATA:     func.func @_Z11bert_node28PA128_A768_KfPA768_S0_PA128_A768_f(%arg0: memref<?x128x768xf32>, %arg1: memref<?x768x768xf32>, %arg2: memref<?x128x768xf32>) attributes {accelerator = "neura"} {
+// CTRL2DATA-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %1 = "neura.grant_once"(%0) : (!neura.data<memref<?x128x768xf32>, i1>) -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %2 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<memref<?x768x768xf32>, i1>
+// CTRL2DATA-NEXT:     %3 = "neura.grant_once"(%2) : (!neura.data<memref<?x768x768xf32>, i1>) -> !neura.data<memref<?x768x768xf32>, i1>
+// CTRL2DATA-NEXT:     %4 = "neura.constant"() <{predicate = true, value = "%arg2"}> : () -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %5 = "neura.grant_once"(%4) : (!neura.data<memref<?x128x768xf32>, i1>) -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %6 = "neura.constant"() <{predicate = true, value = 768 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %7 = "neura.grant_once"(%6) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %8 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %9 = "neura.grant_once"(%8) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %10 = "neura.constant"() <{predicate = true, value = 128 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %11 = "neura.grant_once"(%10) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %12 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %13 = "neura.grant_once"(%12) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %14 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %15 = "neura.phi"(%14, %11) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %16 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %17 = "neura.phi"(%16, %13) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %18 = "neura.icmp"(%17, %15) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %19 = "neura.not"(%18) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %20 = neura.grant_predicate %13, %18 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %21 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %22 = "neura.phi"(%21, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %23 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %24 = "neura.phi"(%23, %20) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %25 = "neura.icmp"(%24, %22) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %13, %25 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %27 = "neura.not"(%25) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %28 = neura.grant_predicate %17, %27 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %29 = neura.grant_predicate %9, %27 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %30 = neura.grant_predicate %11, %27 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %31 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %32 = "neura.phi"(%31, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %33 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %34 = "neura.phi"(%33, %26) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %35 = "neura.icmp"(%34, %32) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %36 = neura.grant_predicate %1, %35 : !neura.data<memref<?x128x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %37 = neura.grant_predicate %13, %35 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %38 = neura.grant_predicate %17, %35 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %39 = neura.grant_predicate %34, %35 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %40 = neura.grant_predicate %3, %35 : !neura.data<memref<?x768x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x768x768xf32>, i1>
+// CTRL2DATA-NEXT:     %41 = neura.grant_predicate %24, %35 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %42 = neura.grant_predicate %5, %35 : !neura.data<memref<?x128x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %43 = neura.grant_predicate %9, %35 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %44 = neura.grant_predicate %7, %35 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %45 = "neura.not"(%35) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %46 = neura.grant_predicate %24, %45 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %47 = neura.grant_predicate %9, %45 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %48 = neura.grant_predicate %7, %45 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %49 = neura.load_indexed %36[%37, %38, %39 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128x768xf32>, i1> : !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %50 = neura.load_indexed %40[%37, %39, %41 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x768x768xf32>, i1> : !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %51 = neura.load_indexed %42[%37, %38, %41 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128x768xf32>, i1> : !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %52 = "neura.fmul"(%49, %50) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %53 = "neura.fadd"(%51, %52) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %53 to %42[%37, %38, %41 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128x768xf32>, i1> : !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %54 = "neura.add"(%39, %43) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %54 -> %33 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %44 -> %31 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %55 = "neura.add"(%46, %47) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %55 -> %23 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %48 -> %21 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %56 = "neura.add"(%28, %29) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %56 -> %16 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %30 -> %14 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     "neura.return"() : () -> ()
+// CTRL2DATA-NEXT:   }

--- a/test/controflow_fuse/complex_nested/complex_nested.mlir
+++ b/test/controflow_fuse/complex_nested/complex_nested.mlir
@@ -1,6 +1,23 @@
 // RUN: mlir-opt %s --lower-affine --convert-scf-to-cf --convert-cf-to-llvm -o %t-llvm.mlir
-// RUN: mlir-neura-opt %t-llvm.mlir --assign-accelerator --lower-arith-to-neura --lower-memref-to-neura --lower-builtin-to-neura --lower-llvm-to-neura | FileCheck %s
-// RUN: mlir-neura-opt %t-llvm.mlir --assign-accelerator --lower-arith-to-neura --lower-memref-to-neura --lower-builtin-to-neura --lower-llvm-to-neura --canonicalize-live-in --leverage-predicated-value --transform-ctrl-to-data-flow | FileCheck %s -check-prefix=CTRL2DATA
+// RUN: mlir-neura-opt %t-llvm.mlir \
+// RUN: --assign-accelerator \
+// RUN: --lower-arith-to-neura \
+// RUN: --lower-memref-to-neura \
+// RUN: --lower-builtin-to-neura \
+// RUN: --lower-llvm-to-neura \
+// RUN: | FileCheck %s
+
+// RUN: mlir-neura-opt %t-llvm.mlir \
+// RUN: --assign-accelerator \
+// RUN: --lower-arith-to-neura \
+// RUN: --lower-memref-to-neura \
+// RUN: --lower-builtin-to-neura \
+// RUN: --lower-llvm-to-neura \
+// RUN: --canonicalize-cast \
+// RUN: --canonicalize-live-in \
+// RUN: --leverage-predicated-value \
+// RUN: --transform-ctrl-to-data-flow \
+// RUN: | FileCheck %s -check-prefix=CTRL2DATA
 
 module attributes {} {
   func.func @_Z14complex_nestedPA32_A32_iPS_(%arg0: memref<?x32x32xi32>, %arg1: memref<?x32xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
@@ -158,204 +175,173 @@ module attributes {} {
 // CHECK-NEXT:     "neura.return"() : () -> ()
 // CHECK-NEXT:   }
 
-// CTRL2DATA:   func.func @_Z14complex_nestedPA32_A32_iPS_(%arg0: memref<?x32x32xi32>, %arg1: memref<?x32xi32>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
+// CTRL2DATA: func.func @_Z14complex_nestedPA32_A32_iPS_(%arg0: memref<?x32x32xi32>, %arg1: memref<?x32xi32>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
 // CTRL2DATA-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<memref<?x32x32xi32>, i1>
-// CTRL2DATA-NEXT:     %1 = "neura.grant_always"(%0) : (!neura.data<memref<?x32x32xi32>, i1>) -> !neura.data<memref<?x32x32xi32>, i1>
-// CTRL2DATA-NEXT:     %2 = "neura.grant_once"(%0) : (!neura.data<memref<?x32x32xi32>, i1>) -> !neura.data<memref<?x32x32xi32>, i1>
-// CTRL2DATA-NEXT:     %3 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<memref<?x32xi32>, i1>
-// CTRL2DATA-NEXT:     %4 = "neura.grant_always"(%3) : (!neura.data<memref<?x32xi32>, i1>) -> !neura.data<memref<?x32xi32>, i1>
-// CTRL2DATA-NEXT:     %5 = "neura.grant_once"(%3) : (!neura.data<memref<?x32xi32>, i1>) -> !neura.data<memref<?x32xi32>, i1>
-// CTRL2DATA-NEXT:     %6 = "neura.constant"() <{predicate = true, value = 1 : index}> : () -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %7 = "neura.grant_always"(%6) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %8 = "neura.grant_once"(%6) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %9 = "neura.constant"() <{predicate = true, value = 32 : index}> : () -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %10 = "neura.grant_always"(%9) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %11 = "neura.grant_once"(%9) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %12 = "neura.constant"() <{predicate = true, value = 128 : i32}> : () -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %13 = "neura.grant_always"(%12) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %14 = "neura.grant_once"(%12) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %15 = "neura.constant"() <{predicate = true, value = -128 : i32}> : () -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %16 = "neura.grant_always"(%15) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %17 = "neura.grant_once"(%15) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %18 = "neura.constant"() <{predicate = true, value = 32 : i32}> : () -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %19 = "neura.grant_always"(%18) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %20 = "neura.grant_once"(%18) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %21 = "neura.constant"() <{predicate = true, value = 0 : i32}> : () -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %22 = "neura.grant_always"(%21) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %23 = "neura.grant_once"(%21) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %24 = "neura.constant"() <{predicate = true, value = 0 : index}> : () -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %25 = "neura.grant_always"(%24) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %26 = "neura.grant_once"(%24) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %27 = "neura.cast"(%24) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %28 = "neura.grant_once"(%27) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %29 = neura.reserve : !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %30 = "neura.phi"(%29, %11) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %31 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %32 = "neura.phi"(%31, %28) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %33 = "neura.cast"(%32) <{cast_type = "int_to_index"}> : (!neura.data<i64, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %34 = "neura.icmp"(%33, %30) <{cmpType = "slt"}> : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %35 = "neura.not"(%34) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %36 = neura.grant_predicate %26, %34 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %37 = "neura.cast"(%36) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %38 = neura.reserve : !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %39 = "neura.phi"(%38, %11) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
+// CTRL2DATA-NEXT:     %1 = "neura.grant_once"(%0) : (!neura.data<memref<?x32x32xi32>, i1>) -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %2 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %3 = "neura.grant_once"(%2) : (!neura.data<memref<?x32xi32>, i1>) -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %4 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %5 = "neura.grant_once"(%4) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %6 = "neura.constant"() <{predicate = true, value = 32 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %7 = "neura.grant_once"(%6) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %8 = "neura.constant"() <{predicate = true, value = 128 : i32}> : () -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %9 = "neura.grant_once"(%8) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %10 = "neura.constant"() <{predicate = true, value = -128 : i32}> : () -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %11 = "neura.grant_once"(%10) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %12 = "neura.constant"() <{predicate = true, value = 32 : i32}> : () -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %13 = "neura.grant_once"(%12) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %14 = "neura.constant"() <{predicate = true, value = 0 : i32}> : () -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %15 = "neura.grant_once"(%14) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %16 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %17 = "neura.grant_once"(%16) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %18 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %19 = "neura.phi"(%18, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %20 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %21 = "neura.phi"(%20, %17) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %22 = "neura.icmp"(%21, %19) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %23 = "neura.not"(%22) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %24 = neura.grant_predicate %17, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %25 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %26 = "neura.phi"(%25, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %27 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %28 = "neura.phi"(%27, %24) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %29 = "neura.icmp"(%28, %26) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %30 = neura.grant_predicate %15, %29 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %31 = neura.grant_predicate %3, %29 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %32 = neura.grant_predicate %21, %29 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %33 = neura.grant_predicate %28, %29 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %34 = neura.grant_predicate %17, %29 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %35 = "neura.not"(%29) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %36 = neura.grant_predicate %17, %35 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %37 = neura.grant_predicate %15, %35 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %30 to %31[%32, %33 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %38 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %39 = "neura.phi"(%38, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %40 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %41 = "neura.phi"(%40, %37) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %42 = "neura.cast"(%41) <{cast_type = "int_to_index"}> : (!neura.data<i64, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %43 = "neura.icmp"(%42, %39) <{cmpType = "slt"}> : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %44 = neura.grant_predicate %23, %43 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %45 = neura.grant_predicate %5, %43 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
-// CTRL2DATA-NEXT:     %46 = neura.grant_predicate %33, %43 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %47 = neura.grant_predicate %42, %43 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %48 = neura.grant_predicate %26, %43 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %49 = "neura.not"(%43) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %50 = neura.grant_predicate %26, %49 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %51 = neura.grant_predicate %23, %49 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %44 to %45[%46, %47 : !neura.data<index, i1>, !neura.data<index, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %52 = "neura.cast"(%48) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %53 = neura.reserve : !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %54 = "neura.phi"(%53, %11) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %55 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %56 = "neura.phi"(%55, %52) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %57 = "neura.cast"(%56) <{cast_type = "int_to_index"}> : (!neura.data<i64, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %58 = "neura.icmp"(%57, %54) <{cmpType = "slt"}> : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %59 = neura.grant_predicate %2, %58 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
-// CTRL2DATA-NEXT:     %60 = neura.grant_predicate %33, %58 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %61 = neura.grant_predicate %42, %58 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %62 = neura.grant_predicate %57, %58 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %63 = neura.grant_predicate %5, %58 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
-// CTRL2DATA-NEXT:     %64 = neura.grant_predicate %8, %58 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %65 = neura.grant_predicate %11, %58 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %66 = "neura.not"(%58) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %67 = neura.grant_predicate %42, %66 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %68 = neura.grant_predicate %8, %66 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %69 = neura.grant_predicate %11, %66 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %70 = neura.load_indexed %59[%60, %61, %62 : !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>] !neura.data<memref<?x32x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %71 = neura.load_indexed %63[%60, %61 : !neura.data<index, i1>, !neura.data<index, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %72 = "neura.add"(%71, %70) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %72 to %63[%60, %61 : !neura.data<index, i1>, !neura.data<index, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %73 = "neura.add"(%62, %64) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %74 = "neura.cast"(%73) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %74 -> %55 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %65 -> %53 : !neura.data<index, i1> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %75 = "neura.add"(%67, %68) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %76 = "neura.cast"(%75) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %76 -> %40 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %69 -> %38 : !neura.data<index, i1> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %77 = "neura.cast"(%50) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %78 = neura.reserve : !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %79 = "neura.phi"(%78, %11) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %80 = neura.reserve : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %81 = "neura.phi"(%80, %51) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %41 = "neura.phi"(%40, %34) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %42 = "neura.icmp"(%41, %39) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %43 = neura.grant_predicate %1, %42 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %44 = neura.grant_predicate %21, %42 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %45 = neura.grant_predicate %28, %42 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %46 = neura.grant_predicate %41, %42 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %47 = neura.grant_predicate %3, %42 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %48 = neura.grant_predicate %5, %42 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %49 = neura.grant_predicate %7, %42 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %50 = "neura.not"(%42) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %51 = neura.grant_predicate %28, %50 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %52 = neura.grant_predicate %5, %50 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %53 = neura.grant_predicate %7, %50 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %54 = neura.load_indexed %43[%44, %45, %46 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %55 = neura.load_indexed %47[%44, %45 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %56 = "neura.add"(%55, %54) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %56 to %47[%44, %45 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %57 = "neura.add"(%46, %48) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %57 -> %40 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %49 -> %38 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %58 = "neura.add"(%51, %52) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %58 -> %27 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %53 -> %25 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %59 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %60 = "neura.phi"(%59, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %61 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %62 = "neura.phi"(%61, %37) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %63 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %64 = "neura.phi"(%63, %36) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %65 = "neura.icmp"(%64, %60) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %66 = neura.grant_predicate %3, %65 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %67 = neura.grant_predicate %21, %65 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %68 = neura.grant_predicate %64, %65 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %69 = neura.grant_predicate %62, %65 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %70 = neura.grant_predicate %5, %65 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %71 = neura.grant_predicate %7, %65 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %72 = "neura.not"(%65) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %73 = neura.grant_predicate %62, %72 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %74 = neura.grant_predicate %13, %72 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %75 = neura.grant_predicate %17, %72 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %76 = neura.load_indexed %66[%67, %68 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %77 = "neura.add"(%69, %76) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %78 = "neura.add"(%68, %70) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %78 -> %63 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %77 -> %61 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %71 -> %59 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %79 = "neura.div"(%73, %74) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %80 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %81 = "neura.phi"(%80, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %82 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %83 = "neura.phi"(%82, %77) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %84 = "neura.cast"(%83) <{cast_type = "int_to_index"}> : (!neura.data<i64, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %85 = "neura.icmp"(%84, %79) <{cmpType = "slt"}> : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %86 = neura.grant_predicate %5, %85 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
-// CTRL2DATA-NEXT:     %87 = neura.grant_predicate %33, %85 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %88 = neura.grant_predicate %84, %85 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %89 = neura.grant_predicate %81, %85 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %90 = neura.grant_predicate %8, %85 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %91 = neura.grant_predicate %11, %85 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %92 = "neura.not"(%85) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %93 = neura.grant_predicate %81, %92 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %94 = neura.grant_predicate %20, %92 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %95 = neura.grant_predicate %26, %92 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %96 = neura.load_indexed %86[%87, %88 : !neura.data<index, i1>, !neura.data<index, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %97 = "neura.add"(%89, %96) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %98 = "neura.add"(%88, %90) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %99 = "neura.cast"(%98) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %99 -> %82 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %97 -> %80 : !neura.data<i32, i1> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %91 -> %78 : !neura.data<index, i1> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %100 = "neura.div"(%93, %94) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %101 = "neura.cast"(%95) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %102 = neura.reserve : !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %103 = "neura.phi"(%102, %11) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %104 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %105 = "neura.phi"(%104, %101) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %106 = "neura.cast"(%105) <{cast_type = "int_to_index"}> : (!neura.data<i64, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %107 = "neura.icmp"(%106, %103) <{cmpType = "slt"}> : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %108 = neura.grant_predicate %26, %107 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %109 = neura.grant_predicate %17, %107 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %110 = "neura.not"(%107) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %111 = neura.grant_predicate %26, %110 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %112 = "neura.cast"(%108) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %113 = neura.reserve : !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %114 = "neura.phi"(%113, %11) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %115 = neura.reserve : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %116 = "neura.phi"(%115, %109) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %117 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %118 = "neura.phi"(%117, %112) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %119 = "neura.cast"(%118) <{cast_type = "int_to_index"}> : (!neura.data<i64, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %120 = "neura.icmp"(%119, %114) <{cmpType = "slt"}> : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %121 = neura.grant_predicate %2, %120 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
-// CTRL2DATA-NEXT:     %122 = neura.grant_predicate %119, %120 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %123 = neura.grant_predicate %106, %120 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %124 = neura.grant_predicate %33, %120 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %125 = neura.grant_predicate %116, %120 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %126 = neura.grant_predicate %8, %120 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %127 = neura.grant_predicate %11, %120 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %128 = "neura.not"(%120) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %129 = neura.grant_predicate %5, %128 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
-// CTRL2DATA-NEXT:     %130 = neura.grant_predicate %33, %128 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %131 = neura.grant_predicate %106, %128 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %132 = neura.grant_predicate %116, %128 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %133 = neura.grant_predicate %14, %128 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %134 = neura.grant_predicate %8, %128 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %135 = neura.grant_predicate %11, %128 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %136 = neura.load_indexed %121[%122, %123, %124 : !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>] !neura.data<memref<?x32x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %137 = "neura.icmp"(%136, %125) <{cmpType = "sgt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %138 = "neura.sel"(%136, %125, %137) : (!neura.data<i32, i1>, !neura.data<i32, i1>, !neura.data<i1, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %139 = "neura.add"(%122, %126) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %140 = "neura.cast"(%139) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %140 -> %117 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %138 -> %115 : !neura.data<i32, i1> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %127 -> %113 : !neura.data<index, i1> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %141 = neura.load_indexed %129[%130, %131 : !neura.data<index, i1>, !neura.data<index, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %142 = "neura.mul"(%141, %132) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %143 = "neura.div"(%142, %133) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %143 to %129[%130, %131 : !neura.data<index, i1>, !neura.data<index, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %144 = "neura.add"(%131, %134) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %145 = "neura.cast"(%144) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %145 -> %104 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %135 -> %102 : !neura.data<index, i1> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %146 = "neura.cast"(%111) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %147 = neura.reserve : !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %148 = "neura.phi"(%147, %11) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %149 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %150 = "neura.phi"(%149, %146) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %151 = "neura.cast"(%150) <{cast_type = "int_to_index"}> : (!neura.data<i64, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %152 = "neura.icmp"(%151, %148) <{cmpType = "slt"}> : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %153 = neura.grant_predicate %5, %152 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
-// CTRL2DATA-NEXT:     %154 = neura.grant_predicate %33, %152 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %155 = neura.grant_predicate %151, %152 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %156 = neura.grant_predicate %100, %152 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %157 = "neura.not"(%152) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %158 = neura.grant_predicate %33, %157 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %159 = neura.grant_predicate %8, %157 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %160 = neura.grant_predicate %11, %157 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %161 = neura.load_indexed %153[%154, %155 : !neura.data<index, i1>, !neura.data<index, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %162 = "neura.icmp"(%161, %156) <{cmpType = "sgt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %163 = neura.grant_predicate %100, %162 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %164 = neura.grant_predicate %5, %162 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
-// CTRL2DATA-NEXT:     %165 = neura.grant_predicate %33, %162 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %166 = neura.grant_predicate %151, %162 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %167 = "neura.not"(%162) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %168 = neura.grant_predicate %151, %167 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %169 = neura.grant_predicate %8, %167 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %170 = neura.grant_predicate %11, %167 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %163 to %164[%165, %166 : !neura.data<index, i1>, !neura.data<index, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %171 = "neura.phi"(%170, %11) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %172 = "neura.phi"(%169, %8) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %173 = "neura.phi"(%168, %151) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %174 = "neura.add"(%173, %172) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %175 = "neura.cast"(%174) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %175 -> %149 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %171 -> %147 : !neura.data<index, i1> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %176 = "neura.add"(%158, %159) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %177 = "neura.cast"(%176) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %177 -> %31 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %160 -> %29 : !neura.data<index, i1> !neura.data<index, i1>
+// CTRL2DATA-NEXT:     %83 = "neura.phi"(%82, %75) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %84 = "neura.icmp"(%83, %81) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %85 = neura.grant_predicate %17, %84 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %86 = neura.grant_predicate %11, %84 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %87 = "neura.not"(%84) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %88 = neura.grant_predicate %17, %87 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %89 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %90 = "neura.phi"(%89, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %91 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %92 = "neura.phi"(%91, %86) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %93 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %94 = "neura.phi"(%93, %85) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %95 = "neura.icmp"(%94, %90) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %96 = neura.grant_predicate %1, %95 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %97 = neura.grant_predicate %94, %95 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %98 = neura.grant_predicate %83, %95 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %99 = neura.grant_predicate %21, %95 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %100 = neura.grant_predicate %92, %95 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %101 = neura.grant_predicate %5, %95 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %102 = neura.grant_predicate %7, %95 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %103 = "neura.not"(%95) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %104 = neura.grant_predicate %3, %103 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %105 = neura.grant_predicate %21, %103 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %106 = neura.grant_predicate %83, %103 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %107 = neura.grant_predicate %92, %103 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %108 = neura.grant_predicate %9, %103 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %109 = neura.grant_predicate %5, %103 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %110 = neura.grant_predicate %7, %103 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %111 = neura.load_indexed %96[%97, %98, %99 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %112 = "neura.icmp"(%111, %100) <{cmpType = "sgt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %113 = "neura.sel"(%111, %100, %112) : (!neura.data<i32, i1>, !neura.data<i32, i1>, !neura.data<i1, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %114 = "neura.add"(%97, %101) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %114 -> %93 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %113 -> %91 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %102 -> %89 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %115 = neura.load_indexed %104[%105, %106 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %116 = "neura.mul"(%115, %107) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %117 = "neura.div"(%116, %108) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %117 to %104[%105, %106 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %118 = "neura.add"(%106, %109) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %118 -> %82 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %110 -> %80 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %119 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %120 = "neura.phi"(%119, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %121 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %122 = "neura.phi"(%121, %88) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %123 = "neura.icmp"(%122, %120) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %124 = neura.grant_predicate %3, %123 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %125 = neura.grant_predicate %21, %123 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %126 = neura.grant_predicate %122, %123 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %127 = neura.grant_predicate %79, %123 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %128 = "neura.not"(%123) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %129 = neura.grant_predicate %21, %128 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %130 = neura.grant_predicate %5, %128 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %131 = neura.grant_predicate %7, %128 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %132 = neura.load_indexed %124[%125, %126 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %133 = "neura.icmp"(%132, %127) <{cmpType = "sgt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %134 = neura.grant_predicate %79, %133 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %135 = neura.grant_predicate %3, %133 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %136 = neura.grant_predicate %21, %133 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %137 = neura.grant_predicate %122, %133 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %138 = "neura.not"(%133) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %139 = neura.grant_predicate %122, %138 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %140 = neura.grant_predicate %5, %138 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %141 = neura.grant_predicate %7, %138 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %134 to %135[%136, %137 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %142 = "neura.phi"(%141, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %143 = "neura.phi"(%140, %5) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %144 = "neura.phi"(%139, %122) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %145 = "neura.add"(%144, %143) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %145 -> %121 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %142 -> %119 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %146 = "neura.add"(%129, %130) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %146 -> %20 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %131 -> %18 : !neura.data<i64, i1> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     "neura.return"() : () -> ()
 // CTRL2DATA-NEXT:   }

--- a/test/controflow_fuse/non_perfect_nested/non_perfect_nested.mlir
+++ b/test/controflow_fuse/non_perfect_nested/non_perfect_nested.mlir
@@ -1,6 +1,23 @@
 // RUN: mlir-opt %s --lower-affine --convert-scf-to-cf --convert-cf-to-llvm -o %t-llvm.mlir
-// RUN: mlir-neura-opt %t-llvm.mlir --assign-accelerator --lower-arith-to-neura --lower-memref-to-neura --lower-builtin-to-neura --lower-llvm-to-neura | FileCheck %s
-// RUN: mlir-neura-opt %t-llvm.mlir --assign-accelerator --lower-arith-to-neura --lower-memref-to-neura --lower-builtin-to-neura --lower-llvm-to-neura --canonicalize-live-in --leverage-predicated-value --transform-ctrl-to-data-flow | FileCheck %s -check-prefix=CTRL2DATA
+// RUN: mlir-neura-opt %t-llvm.mlir \
+// RUN: --assign-accelerator \
+// RUN: --lower-arith-to-neura \
+// RUN: --lower-memref-to-neura \
+// RUN: --lower-builtin-to-neura \
+// RUN: --lower-llvm-to-neura \
+// RUN: | FileCheck %s
+
+// RUN: mlir-neura-opt %t-llvm.mlir \
+// RUN: --assign-accelerator \
+// RUN: --lower-arith-to-neura \
+// RUN: --lower-memref-to-neura \
+// RUN: --lower-builtin-to-neura \
+// RUN: --lower-llvm-to-neura \
+// RUN: --canonicalize-cast \
+// RUN: --canonicalize-live-in \
+// RUN: --leverage-predicated-value \
+// RUN: --transform-ctrl-to-data-flow \
+// RUN: | FileCheck %s -check-prefix=CTRL2DATA
 
 module attributes {} {
   func.func @_Z29non_perfect_extra_computationPA128_iS0_(%arg0: memref<?x128xi32>, %arg1: memref<?x128xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
@@ -122,136 +139,114 @@ module attributes {} {
 
 // CTRL2DATA:   func.func @_Z29non_perfect_extra_computationPA128_iS0_(%arg0: memref<?x128xi32>, %arg1: memref<?x128xi32>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
 // CTRL2DATA-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<memref<?x128xi32>, i1>
-// CTRL2DATA-NEXT:     %1 = "neura.grant_always"(%0) : (!neura.data<memref<?x128xi32>, i1>) -> !neura.data<memref<?x128xi32>, i1>
-// CTRL2DATA-NEXT:     %2 = "neura.grant_once"(%0) : (!neura.data<memref<?x128xi32>, i1>) -> !neura.data<memref<?x128xi32>, i1>
-// CTRL2DATA-NEXT:     %3 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<memref<?x128xi32>, i1>
-// CTRL2DATA-NEXT:     %4 = "neura.grant_always"(%3) : (!neura.data<memref<?x128xi32>, i1>) -> !neura.data<memref<?x128xi32>, i1>
-// CTRL2DATA-NEXT:     %5 = "neura.grant_once"(%3) : (!neura.data<memref<?x128xi32>, i1>) -> !neura.data<memref<?x128xi32>, i1>
-// CTRL2DATA-NEXT:     %6 = "neura.constant"() <{predicate = true, value = 4 : index}> : () -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %7 = "neura.grant_always"(%6) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %8 = "neura.grant_once"(%6) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %9 = "neura.constant"() <{predicate = true, value = 3 : index}> : () -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %10 = "neura.grant_always"(%9) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %11 = "neura.grant_once"(%9) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %12 = "neura.constant"() <{predicate = true, value = 2 : index}> : () -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %13 = "neura.grant_always"(%12) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %14 = "neura.grant_once"(%12) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %15 = "neura.constant"() <{predicate = true, value = 1 : index}> : () -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %16 = "neura.grant_always"(%15) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %17 = "neura.grant_once"(%15) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %18 = "neura.constant"() <{predicate = true, value = 128 : index}> : () -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %19 = "neura.grant_always"(%18) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %20 = "neura.grant_once"(%18) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %21 = "neura.constant"() <{predicate = true, value = 100 : i32}> : () -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %22 = "neura.grant_always"(%21) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %23 = "neura.grant_once"(%21) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %24 = "neura.constant"() <{predicate = true, value = 3 : i32}> : () -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %25 = "neura.grant_always"(%24) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %26 = "neura.grant_once"(%24) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %27 = "neura.constant"() <{predicate = true, value = 2 : i32}> : () -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %28 = "neura.grant_always"(%27) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %29 = "neura.grant_once"(%27) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %30 = "neura.constant"() <{predicate = true, value = 1000 : i32}> : () -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %31 = "neura.grant_always"(%30) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %32 = "neura.grant_once"(%30) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %33 = "neura.constant"() <{predicate = true, value = -1000 : i32}> : () -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %34 = "neura.grant_always"(%33) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %35 = "neura.grant_once"(%33) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %36 = "neura.constant"() <{predicate = true, value = 128 : i32}> : () -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %37 = "neura.grant_always"(%36) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %38 = "neura.grant_once"(%36) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %39 = "neura.constant"() <{predicate = true, value = 0 : i32}> : () -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %40 = "neura.grant_always"(%39) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %41 = "neura.grant_once"(%39) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %42 = "neura.constant"() <{predicate = true, value = 0 : index}> : () -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %43 = "neura.grant_always"(%42) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %44 = "neura.grant_once"(%42) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %45 = "neura.cast"(%42) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %46 = "neura.grant_once"(%45) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %47 = neura.reserve : !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %48 = "neura.phi"(%47, %20) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
+// CTRL2DATA-NEXT:     %1 = "neura.grant_once"(%0) : (!neura.data<memref<?x128xi32>, i1>) -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %2 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %3 = "neura.grant_once"(%2) : (!neura.data<memref<?x128xi32>, i1>) -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %4 = "neura.constant"() <{predicate = true, value = 4 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %5 = "neura.grant_once"(%4) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %6 = "neura.constant"() <{predicate = true, value = 3 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %7 = "neura.grant_once"(%6) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %8 = "neura.constant"() <{predicate = true, value = 2 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %9 = "neura.grant_once"(%8) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %10 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %11 = "neura.grant_once"(%10) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %12 = "neura.constant"() <{predicate = true, value = 128 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %13 = "neura.grant_once"(%12) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %14 = "neura.constant"() <{predicate = true, value = 100 : i32}> : () -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %15 = "neura.grant_once"(%14) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %16 = "neura.constant"() <{predicate = true, value = 3 : i32}> : () -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %17 = "neura.grant_once"(%16) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %18 = "neura.constant"() <{predicate = true, value = 2 : i32}> : () -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %19 = "neura.grant_once"(%18) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %20 = "neura.constant"() <{predicate = true, value = 1000 : i32}> : () -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %21 = "neura.grant_once"(%20) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %22 = "neura.constant"() <{predicate = true, value = -1000 : i32}> : () -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %23 = "neura.grant_once"(%22) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %24 = "neura.constant"() <{predicate = true, value = 128 : i32}> : () -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %25 = "neura.grant_once"(%24) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %26 = "neura.constant"() <{predicate = true, value = 0 : i32}> : () -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %27 = "neura.grant_once"(%26) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %28 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %29 = "neura.grant_once"(%28) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %30 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %31 = "neura.phi"(%30, %13) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %32 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %33 = "neura.phi"(%32, %29) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %34 = "neura.icmp"(%33, %31) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %35 = "neura.not"(%34) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %36 = neura.grant_predicate %33, %34 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %37 = neura.grant_predicate %19, %34 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %38 = neura.grant_predicate %27, %34 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %39 = neura.grant_predicate %17, %34 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %40 = neura.grant_predicate %29, %34 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %41 = neura.grant_predicate %21, %34 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %42 = neura.grant_predicate %23, %34 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %43 = "neura.cast"(%36) <{cast_type = "i64_to_i32"}> : (!neura.data<i64, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %44 = "neura.div"(%43, %37) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %45 = "neura.mul"(%37, %44) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %46 = "neura.sub"(%43, %45) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %47 = "neura.icmp"(%46, %38) <{cmpType = "eq"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %48 = "neura.sel"(%37, %39, %47) : (!neura.data<i32, i1>, !neura.data<i32, i1>, !neura.data<i1, i1>) -> !neura.data<i32, i1>
 // CTRL2DATA-NEXT:     %49 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %50 = "neura.phi"(%49, %46) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %51 = "neura.cast"(%50) <{cast_type = "int_to_index"}> : (!neura.data<i64, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %52 = "neura.icmp"(%51, %48) <{cmpType = "slt"}> : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %53 = "neura.not"(%52) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %54 = neura.grant_predicate %51, %52 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %55 = neura.grant_predicate %29, %52 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %56 = neura.grant_predicate %41, %52 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %57 = neura.grant_predicate %26, %52 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %58 = neura.grant_predicate %44, %52 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %59 = neura.grant_predicate %32, %52 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %60 = neura.grant_predicate %35, %52 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %61 = "neura.cast"(%54) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %62 = "neura.div"(%61, %55) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %63 = "neura.mul"(%55, %62) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %64 = "neura.sub"(%61, %63) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %65 = "neura.icmp"(%64, %56) <{cmpType = "eq"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %66 = "neura.sel"(%55, %57, %65) : (!neura.data<i32, i1>, !neura.data<i32, i1>, !neura.data<i1, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %67 = "neura.cast"(%58) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %68 = neura.reserve : !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %69 = "neura.phi"(%68, %20) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %70 = neura.reserve : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %71 = "neura.phi"(%70, %56) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %72 = neura.reserve : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %73 = "neura.phi"(%72, %60) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %74 = neura.reserve : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %75 = "neura.phi"(%74, %59) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %76 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %77 = "neura.phi"(%76, %67) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %78 = "neura.cast"(%77) <{cast_type = "int_to_index"}> : (!neura.data<i64, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %79 = "neura.icmp"(%78, %69) <{cmpType = "slt"}> : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %80 = neura.grant_predicate %2, %79 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
-// CTRL2DATA-NEXT:     %81 = neura.grant_predicate %51, %79 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %82 = neura.grant_predicate %78, %79 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %83 = neura.grant_predicate %66, %79 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %84 = neura.grant_predicate %5, %79 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
-// CTRL2DATA-NEXT:     %85 = neura.grant_predicate %71, %79 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %86 = neura.grant_predicate %73, %79 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %87 = neura.grant_predicate %75, %79 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %88 = neura.grant_predicate %17, %79 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %89 = neura.grant_predicate %20, %79 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %90 = "neura.not"(%79) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %91 = neura.grant_predicate %71, %90 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %92 = neura.grant_predicate %38, %90 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %93 = neura.grant_predicate %73, %90 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %94 = neura.grant_predicate %75, %90 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %95 = neura.grant_predicate %41, %90 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %96 = neura.load_indexed %80[%81, %82 : !neura.data<index, i1>, !neura.data<index, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %97 = "neura.mul"(%96, %83) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %97 to %84[%81, %82 : !neura.data<index, i1>, !neura.data<index, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %98 = neura.load_indexed %80[%81, %82 : !neura.data<index, i1>, !neura.data<index, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %99 = "neura.add"(%85, %98) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %100 = "neura.icmp"(%98, %86) <{cmpType = "sgt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %101 = "neura.sel"(%98, %86, %100) : (!neura.data<i32, i1>, !neura.data<i32, i1>, !neura.data<i1, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %102 = "neura.icmp"(%98, %87) <{cmpType = "slt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %103 = "neura.sel"(%98, %87, %102) : (!neura.data<i32, i1>, !neura.data<i32, i1>, !neura.data<i1, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %104 = "neura.add"(%82, %88) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %105 = "neura.cast"(%104) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %105 -> %76 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %103 -> %74 : !neura.data<i32, i1> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %101 -> %72 : !neura.data<i32, i1> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %99 -> %70 : !neura.data<i32, i1> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %89 -> %68 : !neura.data<index, i1> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %106 = "neura.div"(%91, %92) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %107 = "neura.sub"(%93, %94) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %108 = "neura.icmp"(%107, %95) <{cmpType = "sgt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %109 = neura.grant_predicate %106, %108 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %110 = neura.grant_predicate %23, %108 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %111 = neura.grant_predicate %107, %108 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %112 = "neura.not"(%108) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %113 = neura.grant_predicate %106, %112 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %114 = "neura.mul"(%109, %110) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %115 = "neura.div"(%114, %111) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %116 = "neura.phi"(%115, %113) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %106 to %5[%51, %44 : !neura.data<index, i1>, !neura.data<index, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %73 to %5[%51, %17 : !neura.data<index, i1>, !neura.data<index, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %75 to %5[%51, %14 : !neura.data<index, i1>, !neura.data<index, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %116 to %5[%51, %11 : !neura.data<index, i1>, !neura.data<index, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %107 to %5[%51, %8 : !neura.data<index, i1>, !neura.data<index, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %117 = "neura.add"(%51, %17) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %118 = "neura.cast"(%117) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %118 -> %49 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %20 -> %47 : !neura.data<index, i1> !neura.data<index, i1>
+// CTRL2DATA-NEXT:     %50 = "neura.phi"(%49, %13) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %51 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %52 = "neura.phi"(%51, %38) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %53 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %54 = "neura.phi"(%53, %42) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %55 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %56 = "neura.phi"(%55, %41) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %57 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %58 = "neura.phi"(%57, %40) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %59 = "neura.icmp"(%58, %50) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %60 = neura.grant_predicate %1, %59 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %61 = neura.grant_predicate %33, %59 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %62 = neura.grant_predicate %58, %59 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %63 = neura.grant_predicate %48, %59 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %64 = neura.grant_predicate %3, %59 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %65 = neura.grant_predicate %52, %59 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %66 = neura.grant_predicate %54, %59 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %67 = neura.grant_predicate %56, %59 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %68 = neura.grant_predicate %11, %59 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %69 = neura.grant_predicate %13, %59 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %70 = "neura.not"(%59) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %71 = neura.grant_predicate %52, %70 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %72 = neura.grant_predicate %25, %70 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %73 = neura.grant_predicate %54, %70 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %74 = neura.grant_predicate %56, %70 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %75 = neura.grant_predicate %27, %70 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %76 = neura.load_indexed %60[%61, %62 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %77 = "neura.mul"(%76, %63) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %77 to %64[%61, %62 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %78 = neura.load_indexed %60[%61, %62 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %79 = "neura.add"(%65, %78) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %80 = "neura.icmp"(%78, %66) <{cmpType = "sgt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %81 = "neura.sel"(%78, %66, %80) : (!neura.data<i32, i1>, !neura.data<i32, i1>, !neura.data<i1, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %82 = "neura.icmp"(%78, %67) <{cmpType = "slt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %83 = "neura.sel"(%78, %67, %82) : (!neura.data<i32, i1>, !neura.data<i32, i1>, !neura.data<i1, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %84 = "neura.add"(%62, %68) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %84 -> %57 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %83 -> %55 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %81 -> %53 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %79 -> %51 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %69 -> %49 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %85 = "neura.div"(%71, %72) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %86 = "neura.sub"(%73, %74) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %87 = "neura.icmp"(%86, %75) <{cmpType = "sgt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %88 = neura.grant_predicate %85, %87 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %89 = neura.grant_predicate %15, %87 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %90 = neura.grant_predicate %86, %87 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %91 = "neura.not"(%87) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %92 = neura.grant_predicate %85, %91 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %93 = "neura.mul"(%88, %89) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %94 = "neura.div"(%93, %90) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %95 = "neura.phi"(%94, %92) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %85 to %3[%33, %29 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %54 to %3[%33, %11 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %56 to %3[%33, %9 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %95 to %3[%33, %7 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %86 to %3[%33, %5 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %96 = "neura.add"(%33, %11) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %96 -> %32 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %13 -> %30 : !neura.data<i64, i1> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     "neura.return"() : () -> ()
 // CTRL2DATA-NEXT:   }

--- a/test/controflow_fuse/perfect_nested/perfect_nested.mlir
+++ b/test/controflow_fuse/perfect_nested/perfect_nested.mlir
@@ -1,7 +1,32 @@
 // RUN: mlir-opt %s --lower-affine --convert-scf-to-cf --convert-cf-to-llvm -o %t-llvm.mlir
-// RUN: mlir-neura-opt %t-llvm.mlir --assign-accelerator --lower-arith-to-neura --lower-memref-to-neura --lower-builtin-to-neura --lower-llvm-to-neura | FileCheck %s
-// RUN: mlir-neura-opt %t-llvm.mlir --assign-accelerator --lower-arith-to-neura --lower-memref-to-neura --lower-builtin-to-neura --lower-llvm-to-neura --canonicalize-cast | FileCheck %s --check-prefix=CAST
-// RUN: mlir-neura-opt %t-llvm.mlir --assign-accelerator --lower-arith-to-neura --lower-memref-to-neura --lower-builtin-to-neura --lower-llvm-to-neura --leverage-predicated-value --transform-ctrl-to-data-flow | FileCheck %s -check-prefix=CTRL2DATA
+// RUN: mlir-neura-opt %t-llvm.mlir \
+// RUN: --assign-accelerator \
+// RUN: --lower-arith-to-neura \
+// RUN: --lower-memref-to-neura \
+// RUN: --lower-builtin-to-neura \
+// RUN: --lower-llvm-to-neura \
+// RUN: | FileCheck %s
+
+// RUN: mlir-neura-opt %t-llvm.mlir \
+// RUN: --assign-accelerator \
+// RUN: --lower-arith-to-neura \
+// RUN: --lower-memref-to-neura \
+// RUN: --lower-builtin-to-neura \
+// RUN: --lower-llvm-to-neura \
+// RUN: --canonicalize-cast \
+// RUN: | FileCheck %s --check-prefix=CAST
+
+// RUN: mlir-neura-opt %t-llvm.mlir \
+// RUN: --assign-accelerator \
+// RUN: --lower-arith-to-neura \
+// RUN: --lower-memref-to-neura \
+// RUN: --lower-builtin-to-neura \
+// RUN: --lower-llvm-to-neura \
+// RUN: --canonicalize-cast \
+// RUN: --canonicalize-live-in \
+// RUN: --leverage-predicated-value \
+// RUN: --transform-ctrl-to-data-flow \
+// RUN: | FileCheck %s -check-prefix=CTRL2DATA
 
 module attributes {} {
   func.func @_Z10bert_node1PA1_A1_A1_A1_A128_bPA1_A128_S1_(%arg0: memref<?x1x1x1x1x128xi8>, %arg1: memref<?x1x128x1x1x128xi8>) attributes {llvm.linkage = #llvm.linkage<external>} {
@@ -71,39 +96,47 @@ module attributes {} {
 // CAST-NEXT:     "neura.return"() : () -> ()
 // CAST-NEXT:   }
 
-// CTRL2DATA: func.func @_Z10bert_node1PA1_A1_A1_A1_A128_bPA1_A128_S1_(%arg0: memref<?x1x1x1x1x128xi8>, %arg1: memref<?x1x128x1x1x128xi8>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
-// CTRL2DATA-NEXT:     %0 = "neura.constant"() <{predicate = true, value = 1 : index}> : () -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %1 = "neura.grant_always"(%0) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 128 : index}> : () -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %3 = "neura.grant_always"(%2) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %4 = "neura.constant"() <{predicate = true, value = 0 : index}> : () -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %5 = "neura.grant_always"(%4) : (!neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %6 = "neura.cast"(%4) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA:     func.func @_Z10bert_node1PA1_A1_A1_A1_A128_bPA1_A128_S1_(%arg0: memref<?x1x1x1x1x128xi8>, %arg1: memref<?x1x128x1x1x128xi8>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
+// CTRL2DATA-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %1 = "neura.grant_once"(%0) : (!neura.data<memref<?x1x1x1x1x128xi8>, i1>) -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %2 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %3 = "neura.grant_once"(%2) : (!neura.data<memref<?x1x128x1x1x128xi8>, i1>) -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %4 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %5 = "neura.grant_once"(%4) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %6 = "neura.constant"() <{predicate = true, value = 128 : i64}> : () -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %7 = "neura.grant_once"(%6) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %8 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %9 = "neura.phi"(%8, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %10 = "neura.cast"(%9) <{cast_type = "int_to_index"}> : (!neura.data<i64, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %11 = "neura.icmp"(%10, %3) <{cmpType = "slt"}> : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %12 = "neura.not"(%11) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %13 = neura.grant_predicate %5, %11 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %14 = "neura.cast"(%13) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %15 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %16 = "neura.phi"(%15, %14) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %17 = "neura.cast"(%16) <{cast_type = "int_to_index"}> : (!neura.data<i64, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %18 = "neura.icmp"(%17, %3) <{cmpType = "slt"}> : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %19 = "neura.not"(%18) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %20 = neura.grant_predicate %5, %18 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %21 = neura.grant_predicate %17, %18 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %22 = neura.load_indexed %arg0[%20, %20, %20, %20, %20, %21 : !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>] memref<?x1x1x1x1x128xi8> : !neura.data<i8, i1>
-// CTRL2DATA-NEXT:     %23 = neura.grant_predicate %10, %18 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %22 to %arg1[%20, %20, %23, %20, %20, %21 : !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>, !neura.data<index, i1>] memref<?x1x128x1x1x128xi8> : !neura.data<i8, i1>
-// CTRL2DATA-NEXT:     %24 = neura.grant_predicate %1, %18 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %25 = "neura.add"(%21, %24) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %26 = "neura.cast"(%25) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %26 -> %15 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %27 = neura.grant_predicate %10, %19 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %28 = neura.grant_predicate %1, %19 : !neura.data<index, i1>, !neura.data<i1, i1> -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %29 = "neura.add"(%27, %28) : (!neura.data<index, i1>, !neura.data<index, i1>) -> !neura.data<index, i1>
-// CTRL2DATA-NEXT:     %30 = "neura.cast"(%29) <{cast_type = "index_to_int"}> : (!neura.data<index, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %30 -> %8 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %8 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %9 = "neura.grant_once"(%8) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %10 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %11 = "neura.phi"(%10, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %12 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %13 = "neura.phi"(%12, %9) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %14 = "neura.icmp"(%13, %11) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %15 = "neura.not"(%14) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %16 = neura.grant_predicate %9, %14 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %17 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %18 = "neura.phi"(%17, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %19 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %20 = "neura.phi"(%19, %16) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %21 = "neura.icmp"(%20, %18) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %22 = neura.grant_predicate %1, %21 : !neura.data<memref<?x1x1x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %23 = neura.grant_predicate %9, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %24 = neura.grant_predicate %20, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %25 = neura.grant_predicate %3, %21 : !neura.data<memref<?x1x128x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %13, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %27 = neura.grant_predicate %5, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %28 = neura.grant_predicate %7, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %29 = "neura.not"(%21) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %30 = neura.grant_predicate %13, %29 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %31 = neura.grant_predicate %5, %29 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %32 = neura.grant_predicate %7, %29 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %33 = neura.load_indexed %22[%23, %23, %23, %23, %23, %24 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x1x1x1x1x128xi8>, i1> : !neura.data<i8, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %33 to %25[%23, %23, %26, %23, %23, %24 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x1x128x1x1x128xi8>, i1> : !neura.data<i8, i1>
+// CTRL2DATA-NEXT:     %34 = "neura.add"(%24, %27) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %34 -> %19 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %28 -> %17 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %35 = "neura.add"(%30, %31) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %35 -> %12 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %32 -> %10 : !neura.data<i64, i1> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     "neura.return"() : () -> ()
+// CTRL2DATA-NEXT:   }

--- a/test/controflow_fuse/simpleloop/simpleloop.mlir
+++ b/test/controflow_fuse/simpleloop/simpleloop.mlir
@@ -1,7 +1,58 @@
-// RUN: mlir-opt %s --lower-affine --convert-scf-to-cf --convert-cf-to-llvm -o %t-llvm.mlir
-// RUN: mlir-neura-opt %t-llvm.mlir --assign-accelerator --lower-arith-to-neura --lower-memref-to-neura --lower-builtin-to-neura --lower-llvm-to-neura | FileCheck %s
-// RUN: mlir-neura-opt %t-llvm.mlir --assign-accelerator --lower-arith-to-neura --lower-memref-to-neura --lower-builtin-to-neura --lower-llvm-to-neura --canonicalize-cast | FileCheck %s --check-prefix=CAST
-// RUN: mlir-neura-opt %t-llvm.mlir --assign-accelerator --lower-arith-to-neura --lower-memref-to-neura --lower-builtin-to-neura --lower-llvm-to-neura --leverage-predicated-value --transform-ctrl-to-data-flow | FileCheck %s -check-prefix=CTRL2DATA
+// RUN: mlir-opt %s \
+// RUN: --lower-affine \
+// RUN: --convert-scf-to-cf \
+// RUN: --convert-cf-to-llvm -o %t-llvm.mlir
+
+// RUN: mlir-neura-opt %t-llvm.mlir \
+// RUN: --assign-accelerator \
+// RUN: --lower-arith-to-neura \
+// RUN: --lower-memref-to-neura \
+// RUN: --lower-builtin-to-neura \
+// RUN: --lower-llvm-to-neura \
+// RUN: | FileCheck %s
+
+// RUN: mlir-neura-opt %t-llvm.mlir \
+// RUN: --assign-accelerator \
+// RUN: --lower-arith-to-neura \
+// RUN: --lower-memref-to-neura \
+// RUN: --lower-builtin-to-neura \
+// RUN: --lower-llvm-to-neura \
+// RUN: --canonicalize-cast | FileCheck %s --check-prefix=CAST
+
+// RUN: mlir-neura-opt %t-llvm.mlir \
+// RUN: --assign-accelerator \
+// RUN: --lower-arith-to-neura \
+// RUN: --lower-memref-to-neura \
+// RUN: --lower-builtin-to-neura \
+// RUN: --lower-llvm-to-neura \
+// RUN: --leverage-predicated-value \
+// RUN: --transform-ctrl-to-data-flow | FileCheck %s -check-prefix=CTRL2DATA
+
+// RUN: mlir-neura-opt %t-llvm.mlir \
+// RUN: --assign-accelerator \ 
+// RUN: --lower-arith-to-neura \
+// RUN: --lower-memref-to-neura \
+// RUN: --lower-builtin-to-neura \
+// RUN: --lower-llvm-to-neura \
+// RUN: --canonicalize-cast \
+// RUN: --canonicalize-live-in \
+// RUN: --leverage-predicated-value \
+// RUN: --transform-ctrl-to-data-flow \
+// RUN: --fuse-control-flow | FileCheck %s -check-prefix=CTRLFUSE
+
+// RUN: mlir-neura-opt %t-llvm.mlir \
+// RUN: --assign-accelerator \
+// RUN: --lower-arith-to-neura \
+// RUN: --lower-memref-to-neura \
+// RUN: --lower-builtin-to-neura \
+// RUN: --lower-llvm-to-neura \
+// RUN: --canonicalize-cast \
+// RUN: --canonicalize-live-in \
+// RUN: --leverage-predicated-value \
+// RUN: --transform-ctrl-to-data-flow \
+// RUN: --fuse-control-flow \
+// RUN: --insert-data-mov \
+// RUN: --map-to-accelerator="mapping-strategy=heuristic" | FileCheck %s -check-prefix=CTRLFUSE-MAPPING
 
 module attributes {} {
   func.func @_Z10simpleloopv() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
@@ -81,3 +132,78 @@ module attributes {} {
 // CTRL2DATA-NEXT:     neura.ctrl_mov %18 -> %9 : !neura.data<i32, i1> !neura.data<i32, i1>
 // CTRL2DATA-NEXT:     "neura.return"(%10) : (!neura.data<i32, i1>) -> ()
 // CTRL2DATA-NEXT:   }
+
+
+// CTRLFUSE:     func.func @_Z10simpleloopv() -> i32 attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
+// CTRLFUSE-NEXT:     %0 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> !neura.data<i64, i1>
+// CTRLFUSE-NEXT:     %1 = "neura.grant_always"(%0) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRLFUSE-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 128 : i64}> : () -> !neura.data<i64, i1>
+// CTRLFUSE-NEXT:     %3 = "neura.grant_always"(%2) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRLFUSE-NEXT:     %4 = "neura.grant_once"(%2) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRLFUSE-NEXT:     %5 = "neura.constant"() <{predicate = true, value = 0 : i32}> : () -> !neura.data<i32, i1>
+// CTRLFUSE-NEXT:     %6 = "neura.grant_once"(%5) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRLFUSE-NEXT:     %7 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
+// CTRLFUSE-NEXT:     %8 = neura.reserve : !neura.data<i64, i1>
+// CTRLFUSE-NEXT:     %9 = "neura.phi"(%8, %4) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRLFUSE-NEXT:     %10 = "neura.constant"() <{predicate = true, value = true}> : () -> !neura.data<i1, i1>
+// CTRLFUSE-NEXT:     %index, %valid = neura.loop_controller(parent_valid = %10, start = %7, end = %9, step = %0) {iterationType = "increment"} : !neura.data<i1, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1> -> !neura.data<i64, i1>, !neura.data<i1, i1>
+// CTRLFUSE-NEXT:     %11 = "neura.not"(%valid) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRLFUSE-NEXT:     %12 = neura.reserve : !neura.data<i32, i1>
+// CTRLFUSE-NEXT:     %13 = "neura.phi"(%12, %6) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRLFUSE-NEXT:     %14 = neura.grant_predicate %13, %valid : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRLFUSE-NEXT:     %15 = neura.grant_predicate %4, %valid : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRLFUSE-NEXT:     %16 = neura.grant_predicate %13, %11 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRLFUSE-NEXT:     %17 = "neura.cast"(%index) <{cast_type = "i64_to_i32"}> : (!neura.data<i64, i1>) -> !neura.data<i32, i1>
+// CTRLFUSE-NEXT:     %18 = "neura.add"(%14, %17) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRLFUSE-NEXT:     neura.ctrl_mov %18 -> %12 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRLFUSE-NEXT:     neura.ctrl_mov %15 -> %8 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRLFUSE-NEXT:     "neura.return"(%16) : (!neura.data<i32, i1>) -> ()
+// CTRLFUSE-NEXT:   }
+
+
+// CTRLFUSE-MAPPING:     func.func @_Z10simpleloopv() -> i32 attributes {CompiledII = 5 : i32, RecMII = 3 : i32, ResMII = 1 : i32, accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
+// CTRLFUSE-MAPPING-NEXT:     %0 = "neura.constant"() <{predicate = true, value = 1 : i64}> {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 0 : i32, x = 1 : i32, y = 1 : i32}]} : () -> !neura.data<i64, i1>
+// CTRLFUSE-MAPPING-NEXT:     %1 = "neura.data_mov"(%0) {mapping_locs = []} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRLFUSE-MAPPING-NEXT:     %2 = "neura.grant_always"(%1) {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 1 : i32, x = 1 : i32, y = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRLFUSE-MAPPING-NEXT:     %3 = "neura.constant"() <{predicate = true, value = 128 : i64}> {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 0 : i32, x = 1 : i32, y = 2 : i32}]} : () -> !neura.data<i64, i1>
+// CTRLFUSE-MAPPING-NEXT:     %4 = "neura.data_mov"(%3) {mapping_locs = []} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRLFUSE-MAPPING-NEXT:     %5 = "neura.grant_always"(%4) {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 1 : i32, x = 1 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRLFUSE-MAPPING-NEXT:     %6 = "neura.data_mov"(%3) {mapping_locs = [{id = 18 : i32, resource = "link", time_step = 0 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRLFUSE-MAPPING-NEXT:     %7 = "neura.grant_once"(%6) {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 1 : i32, x = 2 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRLFUSE-MAPPING-NEXT:     %8 = "neura.constant"() <{predicate = true, value = 0 : i32}> {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 0 : i32, x = 2 : i32, y = 1 : i32}]} : () -> !neura.data<i32, i1>
+// CTRLFUSE-MAPPING-NEXT:     %9 = "neura.data_mov"(%8) {mapping_locs = [{id = 28 : i32, resource = "link", time_step = 0 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRLFUSE-MAPPING-NEXT:     %10 = "neura.grant_once"(%9) {mapping_locs = [{id = 13 : i32, resource = "tile", time_step = 1 : i32, x = 3 : i32, y = 1 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRLFUSE-MAPPING-NEXT:     %11 = "neura.constant"() <{predicate = true, value = 0 : i64}> {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 0 : i32, x = 2 : i32, y = 2 : i32}]} : () -> !neura.data<i64, i1>
+// CTRLFUSE-MAPPING-NEXT:     %12 = neura.reserve : !neura.data<i64, i1>
+// CTRLFUSE-MAPPING-NEXT:     %13 = "neura.data_mov"(%7) {mapping_locs = [{id = 33 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRLFUSE-MAPPING-NEXT:     %14 = "neura.phi"(%12, %13) {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 2 : i32, x = 2 : i32, y = 1 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRLFUSE-MAPPING-NEXT:     %15 = "neura.constant"() <{predicate = true, value = true}> {mapping_locs = [{id = 14 : i32, resource = "tile", time_step = 0 : i32, x = 3 : i32, y = 2 : i32}]} : () -> !neura.data<i1, i1>
+// CTRLFUSE-MAPPING-NEXT:     %16 = "neura.data_mov"(%15) {mapping_locs = [{id = 43 : i32, resource = "link", time_step = 0 : i32}, {id = 43 : i32, resource = "link", time_step = 1 : i32}, {id = 43 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRLFUSE-MAPPING-NEXT:     %17 = "neura.data_mov"(%11) {mapping_locs = []} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRLFUSE-MAPPING-NEXT:     %18 = "neura.data_mov"(%14) {mapping_locs = [{id = 30 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRLFUSE-MAPPING-NEXT:     %19 = "neura.data_mov"(%0) {mapping_locs = [{id = 16 : i32, resource = "link", time_step = 0 : i32}, {id = 18 : i32, resource = "link", time_step = 1 : i32}, {id = 18 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRLFUSE-MAPPING-NEXT:     %index, %valid = neura.loop_controller(parent_valid = %16, start = %17, end = %18, step = %19) {iterationType = "increment", mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 3 : i32, x = 2 : i32, y = 2 : i32}]} : !neura.data<i1, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1> -> !neura.data<i64, i1>, !neura.data<i1, i1>
+// CTRLFUSE-MAPPING-NEXT:     %20 = "neura.data_mov"(%valid) {mapping_locs = [{id = 31 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRLFUSE-MAPPING-NEXT:     %21 = "neura.not"(%20) {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 4 : i32, x = 1 : i32, y = 2 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRLFUSE-MAPPING-NEXT:     %22 = neura.reserve : !neura.data<i32, i1>
+// CTRLFUSE-MAPPING-NEXT:     %23 = "neura.data_mov"(%10) {mapping_locs = [{id = 42 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRLFUSE-MAPPING-NEXT:     %24 = "neura.phi"(%22, %23) {mapping_locs = [{id = 14 : i32, resource = "tile", time_step = 2 : i32, x = 3 : i32, y = 2 : i32}]} : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRLFUSE-MAPPING-NEXT:     %25 = "neura.data_mov"(%24) {mapping_locs = []} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRLFUSE-MAPPING-NEXT:     %26 = "neura.data_mov"(%valid) {mapping_locs = [{id = 32 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRLFUSE-MAPPING-NEXT:     %27 = neura.grant_predicate %25, %26 {mapping_locs = [{id = 14 : i32, resource = "tile", time_step = 4 : i32, x = 3 : i32, y = 2 : i32}]} : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRLFUSE-MAPPING-NEXT:     %28 = "neura.data_mov"(%7) {mapping_locs = [{id = 31 : i32, resource = "link", time_step = 1 : i32}, {id = 19 : i32, resource = "link", time_step = 2 : i32}, {id = 14 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRLFUSE-MAPPING-NEXT:     %29 = "neura.data_mov"(%valid) {mapping_locs = [{id = 33 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRLFUSE-MAPPING-NEXT:     %30 = neura.grant_predicate %28, %29 {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 4 : i32, x = 2 : i32, y = 1 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRLFUSE-MAPPING-NEXT:     %31 = "neura.data_mov"(%24) {mapping_locs = [{id = 45 : i32, resource = "link", time_step = 2 : i32}, {id = 46 : i32, resource = "link", time_step = 3 : i32}, {id = 35 : i32, resource = "link", time_step = 4 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRLFUSE-MAPPING-NEXT:     %32 = "neura.data_mov"(%21) {mapping_locs = [{id = 20 : i32, resource = "link", time_step = 4 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRLFUSE-MAPPING-NEXT:     %33 = neura.grant_predicate %31, %32 {mapping_locs = [{id = 7 : i32, resource = "tile", time_step = 5 : i32, x = 1 : i32, y = 3 : i32}]} : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRLFUSE-MAPPING-NEXT:     %34 = "neura.data_mov"(%index) {mapping_locs = []} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRLFUSE-MAPPING-NEXT:     %35 = "neura.cast"(%34) <{cast_type = "i64_to_i32"}> {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 4 : i32, x = 2 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i32, i1>
+// CTRLFUSE-MAPPING-NEXT:     %36 = "neura.data_mov"(%27) {mapping_locs = [{id = 45 : i32, resource = "link", time_step = 4 : i32}, {id = 45 : i32, resource = "link", time_step = 5 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRLFUSE-MAPPING-NEXT:     %37 = "neura.data_mov"(%35) {mapping_locs = [{id = 34 : i32, resource = "link", time_step = 4 : i32}, {id = 36 : i32, resource = "link", time_step = 5 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRLFUSE-MAPPING-NEXT:     %38 = "neura.add"(%36, %37) {mapping_locs = [{id = 15 : i32, resource = "tile", time_step = 6 : i32, x = 3 : i32, y = 3 : i32}]} : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRLFUSE-MAPPING-NEXT:     neura.ctrl_mov %38 -> %22 {mapping_locs = [{id = 47 : i32, resource = "link", time_step = 6 : i32}]} : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRLFUSE-MAPPING-NEXT:     neura.ctrl_mov %30 -> %12 {mapping_locs = []} : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRLFUSE-MAPPING-NEXT:     %39 = "neura.data_mov"(%33) {mapping_locs = []} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRLFUSE-MAPPING-NEXT:     "neura.return"(%39) {mapping_locs = [{id = 7 : i32, resource = "tile", time_step = 6 : i32, x = 1 : i32, y = 3 : i32}]} : (!neura.data<i32, i1>) -> ()
+// CTRLFUSE-MAPPING-NEXT:   }

--- a/test/neura/ctrl/branch_for.mlir
+++ b/test/neura/ctrl/branch_for.mlir
@@ -35,7 +35,7 @@
 // RUN:   --leverage-predicated-value \
 // RUN:   --transform-ctrl-to-data-flow \
 // RUN:   --insert-data-mov \
-// RUN:   --map-to-accelerator="mapping-strategy=simple" \
+// RUN:   --map-to-accelerator="mapping-strategy=heuristic" \
 // RUN:   | FileCheck %s -check-prefix=MAPPING
 
 // RUN: mlir-neura-opt %s \
@@ -45,7 +45,7 @@
 // RUN:   --leverage-predicated-value \
 // RUN:   --transform-ctrl-to-data-flow \
 // RUN:   --insert-data-mov \
-// RUN:   --map-to-accelerator="mapping-strategy=simple" \
+// RUN:   --map-to-accelerator="mapping-strategy=heuristic" \
 // RUN:   --generate-code
 // RUN: FileCheck %s --input-file=generated-instructions.json -check-prefix=INST
 
@@ -100,197 +100,181 @@ func.func @loop_test() -> f32 {
 // CANONICALIZE-NEXT:     "neura.return"(%13) : (!neura.data<f32, i1>) -> ()
 // CANONICALIZE-NEXT:   }
 
-// CTRL2DATA:       func.func @loop_test() -> f32 attributes {accelerator = "neura"} {
+// CTRL2DATA:     func.func @loop_test() -> f32 attributes {accelerator = "neura"} {
 // CTRL2DATA-NEXT:     %0 = "neura.constant"() <{predicate = true, value = 10 : i64}> : () -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %1 = "neura.grant_always"(%0) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %2 = "neura.grant_once"(%0) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %3 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %4 = "neura.grant_once"(%3) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %5 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %6 = "neura.grant_always"(%5) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %7 = "neura.grant_once"(%5) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %8 = "neura.constant"() <{predicate = true, value = 3.000000e+00 : f32}> : () -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %9 = "neura.grant_always"(%8) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %10 = "neura.grant_once"(%8) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %11 = "neura.constant"() <{predicate = true, value = 0.000000e+00 : f32}> : () -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %12 = "neura.grant_once"(%11) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %13 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %14 = "neura.phi"(%13, %2) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %15 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %16 = "neura.phi"(%15, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %17 = neura.reserve : !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %18 = "neura.phi"(%17, %10) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %19 = neura.reserve : !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %20 = "neura.phi"(%19, %12) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %21 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %22 = "neura.phi"(%21, %4) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %23 = "neura.fadd"(%20, %18) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %24 = "neura.add"(%22, %16) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %25 = "neura.icmp"(%24, %14) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %24, %25 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %26 -> %21 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %27 = neura.grant_predicate %23, %25 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %27 -> %19 : !neura.data<f32, i1> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %28 = neura.grant_predicate %10, %25 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %28 -> %17 : !neura.data<f32, i1> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %29 = neura.grant_predicate %7, %25 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %29 -> %15 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %30 = neura.grant_predicate %2, %25 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %30 -> %13 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %31 = "neura.not"(%25) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %32 = neura.grant_predicate %23, %31 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     "neura.return"(%32) : (!neura.data<f32, i1>) -> ()
+// CTRL2DATA-NEXT:     %1 = "neura.grant_once"(%0) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %3 = "neura.grant_once"(%2) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %4 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %5 = "neura.grant_once"(%4) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %6 = "neura.constant"() <{predicate = true, value = 3.000000e+00 : f32}> : () -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %7 = "neura.grant_once"(%6) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %8 = "neura.constant"() <{predicate = true, value = 0.000000e+00 : f32}> : () -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %9 = "neura.grant_once"(%8) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %10 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %11 = "neura.phi"(%10, %1) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %12 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %13 = "neura.phi"(%12, %5) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %14 = neura.reserve : !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %15 = "neura.phi"(%14, %7) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %16 = neura.reserve : !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %17 = "neura.phi"(%16, %9) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %18 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %19 = "neura.phi"(%18, %3) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %20 = "neura.fadd"(%17, %15) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %21 = "neura.add"(%19, %13) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %22 = "neura.icmp"(%21, %11) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %23 = neura.grant_predicate %21, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %23 -> %18 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %24 = neura.grant_predicate %20, %22 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %24 -> %16 : !neura.data<f32, i1> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %25 = neura.grant_predicate %7, %22 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %25 -> %14 : !neura.data<f32, i1> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %5, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %26 -> %12 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %27 = neura.grant_predicate %1, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %27 -> %10 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %28 = "neura.not"(%22) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %29 = neura.grant_predicate %20, %28 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     "neura.return"(%29) : (!neura.data<f32, i1>) -> ()
 // CTRL2DATA-NEXT:   }
 
-// MOV:       func.func @loop_test() -> f32 attributes {accelerator = "neura"} {
+// MOV:     func.func @loop_test() -> f32 attributes {accelerator = "neura"} {
 // MOV-NEXT:     %0 = "neura.constant"() <{predicate = true, value = 10 : i64}> : () -> !neura.data<i64, i1>
 // MOV-NEXT:     %1 = "neura.data_mov"(%0) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %2 = "neura.grant_always"(%1) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %3 = "neura.data_mov"(%0) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %4 = "neura.grant_once"(%3) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %5 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
-// MOV-NEXT:     %6 = "neura.data_mov"(%5) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %7 = "neura.grant_once"(%6) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %8 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> !neura.data<i64, i1>
-// MOV-NEXT:     %9 = "neura.data_mov"(%8) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %10 = "neura.grant_always"(%9) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %11 = "neura.data_mov"(%8) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %12 = "neura.grant_once"(%11) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %13 = "neura.constant"() <{predicate = true, value = 3.000000e+00 : f32}> : () -> !neura.data<f32, i1>
-// MOV-NEXT:     %14 = "neura.data_mov"(%13) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MOV-NEXT:     %15 = "neura.grant_always"(%14) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MOV-NEXT:     %16 = "neura.data_mov"(%13) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MOV-NEXT:     %17 = "neura.grant_once"(%16) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MOV-NEXT:     %18 = "neura.constant"() <{predicate = true, value = 0.000000e+00 : f32}> : () -> !neura.data<f32, i1>
-// MOV-NEXT:     %19 = "neura.data_mov"(%18) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MOV-NEXT:     %20 = "neura.grant_once"(%19) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MOV-NEXT:     %21 = neura.reserve : !neura.data<i64, i1>
-// MOV-NEXT:     %22 = "neura.data_mov"(%4) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %23 = "neura.phi"(%21, %22) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %24 = neura.reserve : !neura.data<i64, i1>
-// MOV-NEXT:     %25 = "neura.data_mov"(%12) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %26 = "neura.phi"(%24, %25) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %27 = neura.reserve : !neura.data<f32, i1>
-// MOV-NEXT:     %28 = "neura.data_mov"(%17) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MOV-NEXT:     %29 = "neura.phi"(%27, %28) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MOV-NEXT:     %30 = neura.reserve : !neura.data<f32, i1>
-// MOV-NEXT:     %31 = "neura.data_mov"(%20) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MOV-NEXT:     %32 = "neura.phi"(%30, %31) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MOV-NEXT:     %33 = neura.reserve : !neura.data<i64, i1>
-// MOV-NEXT:     %34 = "neura.data_mov"(%7) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %35 = "neura.phi"(%33, %34) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %36 = "neura.data_mov"(%32) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MOV-NEXT:     %37 = "neura.data_mov"(%29) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MOV-NEXT:     %38 = "neura.fadd"(%36, %37) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MOV-NEXT:     %2 = "neura.grant_once"(%1) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %3 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
+// MOV-NEXT:     %4 = "neura.data_mov"(%3) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %5 = "neura.grant_once"(%4) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %6 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> !neura.data<i64, i1>
+// MOV-NEXT:     %7 = "neura.data_mov"(%6) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %8 = "neura.grant_once"(%7) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %9 = "neura.constant"() <{predicate = true, value = 3.000000e+00 : f32}> : () -> !neura.data<f32, i1>
+// MOV-NEXT:     %10 = "neura.data_mov"(%9) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MOV-NEXT:     %11 = "neura.grant_once"(%10) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MOV-NEXT:     %12 = "neura.constant"() <{predicate = true, value = 0.000000e+00 : f32}> : () -> !neura.data<f32, i1>
+// MOV-NEXT:     %13 = "neura.data_mov"(%12) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MOV-NEXT:     %14 = "neura.grant_once"(%13) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MOV-NEXT:     %15 = neura.reserve : !neura.data<i64, i1>
+// MOV-NEXT:     %16 = "neura.data_mov"(%2) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %17 = "neura.phi"(%15, %16) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %18 = neura.reserve : !neura.data<i64, i1>
+// MOV-NEXT:     %19 = "neura.data_mov"(%8) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %20 = "neura.phi"(%18, %19) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %21 = neura.reserve : !neura.data<f32, i1>
+// MOV-NEXT:     %22 = "neura.data_mov"(%11) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MOV-NEXT:     %23 = "neura.phi"(%21, %22) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MOV-NEXT:     %24 = neura.reserve : !neura.data<f32, i1>
+// MOV-NEXT:     %25 = "neura.data_mov"(%14) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MOV-NEXT:     %26 = "neura.phi"(%24, %25) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MOV-NEXT:     %27 = neura.reserve : !neura.data<i64, i1>
+// MOV-NEXT:     %28 = "neura.data_mov"(%5) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %29 = "neura.phi"(%27, %28) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %30 = "neura.data_mov"(%26) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MOV-NEXT:     %31 = "neura.data_mov"(%23) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MOV-NEXT:     %32 = "neura.fadd"(%30, %31) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MOV-NEXT:     %33 = "neura.data_mov"(%29) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %34 = "neura.data_mov"(%20) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %35 = "neura.add"(%33, %34) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %36 = "neura.data_mov"(%35) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %37 = "neura.data_mov"(%17) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %38 = "neura.icmp"(%36, %37) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
 // MOV-NEXT:     %39 = "neura.data_mov"(%35) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %40 = "neura.data_mov"(%26) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %41 = "neura.add"(%39, %40) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %42 = "neura.data_mov"(%41) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %43 = "neura.data_mov"(%23) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %44 = "neura.icmp"(%42, %43) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// MOV-NEXT:     %45 = "neura.data_mov"(%41) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %46 = "neura.data_mov"(%44) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MOV-NEXT:     %47 = neura.grant_predicate %45, %46 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// MOV-NEXT:     neura.ctrl_mov %47 -> %33 : !neura.data<i64, i1> !neura.data<i64, i1>
-// MOV-NEXT:     %48 = "neura.data_mov"(%38) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MOV-NEXT:     %49 = "neura.data_mov"(%44) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MOV-NEXT:     %50 = neura.grant_predicate %48, %49 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// MOV-NEXT:     neura.ctrl_mov %50 -> %30 : !neura.data<f32, i1> !neura.data<f32, i1>
-// MOV-NEXT:     %51 = "neura.data_mov"(%17) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MOV-NEXT:     %52 = "neura.data_mov"(%44) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MOV-NEXT:     %53 = neura.grant_predicate %51, %52 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// MOV-NEXT:     neura.ctrl_mov %53 -> %27 : !neura.data<f32, i1> !neura.data<f32, i1>
-// MOV-NEXT:     %54 = "neura.data_mov"(%12) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %55 = "neura.data_mov"(%44) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MOV-NEXT:     %56 = neura.grant_predicate %54, %55 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// MOV-NEXT:     neura.ctrl_mov %56 -> %24 : !neura.data<i64, i1> !neura.data<i64, i1>
-// MOV-NEXT:     %57 = "neura.data_mov"(%4) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MOV-NEXT:     %58 = "neura.data_mov"(%44) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MOV-NEXT:     %59 = neura.grant_predicate %57, %58 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// MOV-NEXT:     neura.ctrl_mov %59 -> %21 : !neura.data<i64, i1> !neura.data<i64, i1>
-// MOV-NEXT:     %60 = "neura.data_mov"(%44) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MOV-NEXT:     %61 = "neura.not"(%60) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MOV-NEXT:     %62 = "neura.data_mov"(%38) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MOV-NEXT:     %63 = "neura.data_mov"(%61) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MOV-NEXT:     %64 = neura.grant_predicate %62, %63 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// MOV-NEXT:     %65 = "neura.data_mov"(%64) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MOV-NEXT:     "neura.return"(%65) : (!neura.data<f32, i1>) -> ()
-// MOV-NEXT:   }
+// MOV-NEXT:     %40 = "neura.data_mov"(%38) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MOV-NEXT:     %41 = neura.grant_predicate %39, %40 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// MOV-NEXT:     neura.ctrl_mov %41 -> %27 : !neura.data<i64, i1> !neura.data<i64, i1>
+// MOV-NEXT:     %42 = "neura.data_mov"(%32) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MOV-NEXT:     %43 = "neura.data_mov"(%38) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MOV-NEXT:     %44 = neura.grant_predicate %42, %43 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// MOV-NEXT:     neura.ctrl_mov %44 -> %24 : !neura.data<f32, i1> !neura.data<f32, i1>
+// MOV-NEXT:     %45 = "neura.data_mov"(%11) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MOV-NEXT:     %46 = "neura.data_mov"(%38) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MOV-NEXT:     %47 = neura.grant_predicate %45, %46 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// MOV-NEXT:     neura.ctrl_mov %47 -> %21 : !neura.data<f32, i1> !neura.data<f32, i1>
+// MOV-NEXT:     %48 = "neura.data_mov"(%8) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %49 = "neura.data_mov"(%38) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MOV-NEXT:     %50 = neura.grant_predicate %48, %49 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// MOV-NEXT:     neura.ctrl_mov %50 -> %18 : !neura.data<i64, i1> !neura.data<i64, i1>
+// MOV-NEXT:     %51 = "neura.data_mov"(%2) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %52 = "neura.data_mov"(%38) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MOV-NEXT:     %53 = neura.grant_predicate %51, %52 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// MOV-NEXT:     neura.ctrl_mov %53 -> %15 : !neura.data<i64, i1> !neura.data<i64, i1>
+// MOV-NEXT:     %54 = "neura.data_mov"(%38) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MOV-NEXT:     %55 = "neura.not"(%54) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MOV-NEXT:     %56 = "neura.data_mov"(%32) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MOV-NEXT:     %57 = "neura.data_mov"(%55) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MOV-NEXT:     %58 = neura.grant_predicate %56, %57 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// MOV-NEXT:     %59 = "neura.data_mov"(%58) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MOV-NEXT:     "neura.return"(%59) : (!neura.data<f32, i1>) -> ()
 
-// MAPPING:      func.func @loop_test() -> f32 attributes {CompiledII = 7 : i32, RecMII = 4 : i32, ResMII = 2 : i32, accelerator = "neura"} {
-// MAPPING-NEXT:   %0 = "neura.constant"() <{predicate = true, value = 10 : i64}> {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 0 : i32, x = 2 : i32, y = 1 : i32}]} : () -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %1 = "neura.data_mov"(%0) {mapping_locs = [{id = 20 : i32, resource = "link", time_step = 0 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %2 = "neura.grant_always"(%1) {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 1 : i32, x = 2 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %3 = "neura.data_mov"(%0) {mapping_locs = [{id = 17 : i32, resource = "link", time_step = 0 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %4 = "neura.grant_once"(%3) {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 1 : i32, x = 1 : i32, y = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %5 = "neura.constant"() <{predicate = true, value = 0 : i64}> {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 0 : i32, x = 2 : i32, y = 2 : i32}]} : () -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %6 = "neura.data_mov"(%5) {mapping_locs = [{id = 31 : i32, resource = "link", time_step = 0 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %7 = "neura.grant_once"(%6) {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 1 : i32, x = 1 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %8 = "neura.constant"() <{predicate = true, value = 1 : i64}> {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 0 : i32, x = 1 : i32, y = 2 : i32}]} : () -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %9 = "neura.data_mov"(%8) {mapping_locs = [{id = 30 : i32, resource = "link", time_step = 0 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %10 = "neura.grant_always"(%9) {mapping_locs = [{id = 13 : i32, resource = "tile", time_step = 1 : i32, x = 1 : i32, y = 3 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %11 = "neura.data_mov"(%8) {mapping_locs = []} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %12 = "neura.grant_once"(%11) {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 2 : i32, x = 1 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %13 = "neura.constant"() <{predicate = true, value = 3.000000e+00 : f32}> {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 0 : i32, x = 1 : i32, y = 1 : i32}]} : () -> !neura.data<f32, i1>
-// MAPPING-NEXT:   %14 = "neura.data_mov"(%13) {mapping_locs = [{id = 14 : i32, resource = "link", time_step = 0 : i32}, {id = 24 : i32, resource = "register", time_step = 1 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:   %15 = "neura.grant_always"(%14) {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 2 : i32, x = 2 : i32, y = 1 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:   %16 = "neura.data_mov"(%13) {mapping_locs = [{id = 13 : i32, resource = "link", time_step = 0 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:   %17 = "neura.grant_once"(%16) {mapping_locs = [{id = 4 : i32, resource = "tile", time_step = 1 : i32, x = 0 : i32, y = 1 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:   %18 = "neura.constant"() <{predicate = true, value = 0.000000e+00 : f32}> {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 1 : i32, x = 2 : i32, y = 1 : i32}]} : () -> !neura.data<f32, i1>
-// MAPPING-NEXT:   %19 = "neura.data_mov"(%18) {mapping_locs = [{id = 17 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:   %20 = "neura.grant_once"(%19) {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 2 : i32, x = 1 : i32, y = 1 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:   %21 = neura.reserve : !neura.data<i64, i1>
-// MAPPING-NEXT:   %22 = "neura.data_mov"(%4) {mapping_locs = [{id = 16 : i32, resource = "link", time_step = 1 : i32}, {id = 36 : i32, resource = "register", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %23 = "neura.phi"(%21, %22) {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 3 : i32, x = 1 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %24 = neura.reserve : !neura.data<i64, i1>
-// MAPPING-NEXT:   %25 = "neura.data_mov"(%12) {mapping_locs = [{id = 28 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %26 = "neura.phi"(%24, %25) {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 3 : i32, x = 2 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %27 = neura.reserve : !neura.data<f32, i1>
-// MAPPING-NEXT:   %28 = "neura.data_mov"(%17) {mapping_locs = [{id = 10 : i32, resource = "link", time_step = 1 : i32}, {id = 14 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:   %29 = "neura.phi"(%27, %28) {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 3 : i32, x = 2 : i32, y = 1 : i32}]} : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:   %30 = neura.reserve : !neura.data<f32, i1>
-// MAPPING-NEXT:   %31 = "neura.data_mov"(%20) {mapping_locs = []} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:   %32 = "neura.phi"(%30, %31) {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 3 : i32, x = 1 : i32, y = 1 : i32}]} : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:   %33 = neura.reserve : !neura.data<i64, i1>
-// MAPPING-NEXT:   %34 = "neura.data_mov"(%7) {mapping_locs = [{id = 28 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %35 = "neura.phi"(%33, %34) {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 2 : i32, x = 2 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %36 = "neura.data_mov"(%32) {mapping_locs = []} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:   %37 = "neura.data_mov"(%29) {mapping_locs = [{id = 17 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:   %38 = "neura.fadd"(%36, %37) {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 4 : i32, x = 1 : i32, y = 1 : i32}]} : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:   %39 = "neura.data_mov"(%35) {mapping_locs = [{id = 33 : i32, resource = "link", time_step = 2 : i32}, {id = 24 : i32, resource = "register", time_step = 3 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %40 = "neura.data_mov"(%26) {mapping_locs = [{id = 33 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %41 = "neura.add"(%39, %40) {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 4 : i32, x = 2 : i32, y = 1 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %42 = "neura.data_mov"(%41) {mapping_locs = [{id = 20 : i32, resource = "link", time_step = 4 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %43 = "neura.data_mov"(%23) {mapping_locs = [{id = 28 : i32, resource = "link", time_step = 3 : i32}, {id = 40 : i32, resource = "register", time_step = 4 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %44 = "neura.icmp"(%42, %43) <{cmpType = "slt"}> {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 5 : i32, x = 2 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:   %45 = "neura.data_mov"(%41) {mapping_locs = [{id = 17 : i32, resource = "link", time_step = 4 : i32}, {id = 16 : i32, resource = "link", time_step = 5 : i32}, {id = 28 : i32, resource = "link", time_step = 6 : i32}, {id = 40 : i32, resource = "register", time_step = 7 : i32}, {id = 40 : i32, resource = "register", time_step = 8 : i32}, {id = 40 : i32, resource = "register", time_step = 9 : i32}, {id = 40 : i32, resource = "register", time_step = 10 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %46 = "neura.data_mov"(%44) {mapping_locs = []} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:   %47 = neura.grant_predicate %45, %46 {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 11 : i32, x = 2 : i32, y = 2 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// MAPPING-NEXT:   neura.ctrl_mov %47 -> %33 {mapping_locs = []} : !neura.data<i64, i1> !neura.data<i64, i1>
-// MAPPING-NEXT:   %48 = "neura.data_mov"(%38) {mapping_locs = [{id = 14 : i32, resource = "link", time_step = 4 : i32}, {id = 18 : i32, resource = "link", time_step = 5 : i32}, {id = 23 : i32, resource = "link", time_step = 6 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:   %49 = "neura.data_mov"(%44) {mapping_locs = [{id = 32 : i32, resource = "link", time_step = 5 : i32}, {id = 44 : i32, resource = "register", time_step = 6 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:   %50 = neura.grant_predicate %48, %49 {mapping_locs = [{id = 11 : i32, resource = "tile", time_step = 7 : i32, x = 3 : i32, y = 2 : i32}]} : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// MAPPING-NEXT:   neura.ctrl_mov %50 -> %30 {mapping_locs = [{id = 35 : i32, resource = "link", time_step = 7 : i32}, {id = 31 : i32, resource = "link", time_step = 8 : i32}, {id = 29 : i32, resource = "link", time_step = 9 : i32}]} : !neura.data<f32, i1> !neura.data<f32, i1>
-// MAPPING-NEXT:   %51 = "neura.data_mov"(%17) {mapping_locs = [{id = 12 : i32, resource = "link", time_step = 1 : i32}, {id = 24 : i32, resource = "link", time_step = 2 : i32}, {id = 30 : i32, resource = "link", time_step = 3 : i32}, {id = 41 : i32, resource = "link", time_step = 4 : i32}, {id = 56 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:   %52 = "neura.data_mov"(%44) {mapping_locs = [{id = 34 : i32, resource = "link", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:   %53 = neura.grant_predicate %51, %52 {mapping_locs = [{id = 14 : i32, resource = "tile", time_step = 6 : i32, x = 2 : i32, y = 3 : i32}]} : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// MAPPING-NEXT:   neura.ctrl_mov %53 -> %27 {mapping_locs = [{id = 45 : i32, resource = "link", time_step = 6 : i32}, {id = 33 : i32, resource = "link", time_step = 7 : i32}, {id = 26 : i32, resource = "register", time_step = 8 : i32}, {id = 26 : i32, resource = "register", time_step = 9 : i32}]} : !neura.data<f32, i1> !neura.data<f32, i1>
-// MAPPING-NEXT:   %54 = "neura.data_mov"(%12) {mapping_locs = [{id = 30 : i32, resource = "link", time_step = 2 : i32}, {id = 41 : i32, resource = "link", time_step = 3 : i32}, {id = 45 : i32, resource = "link", time_step = 4 : i32}, {id = 40 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %55 = "neura.data_mov"(%44) {mapping_locs = []} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:   %56 = neura.grant_predicate %54, %55 {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 6 : i32, x = 2 : i32, y = 2 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// MAPPING-NEXT:   neura.ctrl_mov %56 -> %24 {mapping_locs = []} : !neura.data<i64, i1> !neura.data<i64, i1>
-// MAPPING-NEXT:   %57 = "neura.data_mov"(%4) {mapping_locs = [{id = 14 : i32, resource = "link", time_step = 1 : i32}, {id = 25 : i32, resource = "register", time_step = 2 : i32}, {id = 25 : i32, resource = "register", time_step = 3 : i32}, {id = 25 : i32, resource = "register", time_step = 4 : i32}, {id = 25 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:   %58 = "neura.data_mov"(%44) {mapping_locs = [{id = 33 : i32, resource = "link", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:   %59 = neura.grant_predicate %57, %58 {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 6 : i32, x = 2 : i32, y = 1 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// MAPPING-NEXT:   neura.ctrl_mov %59 -> %21 {mapping_locs = [{id = 17 : i32, resource = "link", time_step = 6 : i32}, {id = 16 : i32, resource = "link", time_step = 7 : i32}, {id = 37 : i32, resource = "register", time_step = 8 : i32}, {id = 37 : i32, resource = "register", time_step = 9 : i32}]} : !neura.data<i64, i1> !neura.data<i64, i1>
-// MAPPING-NEXT:   %60 = "neura.data_mov"(%44) {mapping_locs = [{id = 31 : i32, resource = "link", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:   %61 = "neura.not"(%60) {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 6 : i32, x = 1 : i32, y = 2 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:   %62 = "neura.data_mov"(%38) {mapping_locs = [{id = 13 : i32, resource = "link", time_step = 4 : i32}, {id = 12 : i32, resource = "link", time_step = 5 : i32}, {id = 32 : i32, resource = "register", time_step = 6 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:   %63 = "neura.data_mov"(%61) {mapping_locs = [{id = 27 : i32, resource = "link", time_step = 6 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:   %64 = neura.grant_predicate %62, %63 {mapping_locs = [{id = 8 : i32, resource = "tile", time_step = 7 : i32, x = 0 : i32, y = 2 : i32}]} : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// MAPPING-NEXT:   %65 = "neura.data_mov"(%64) {mapping_locs = []} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:   "neura.return"(%65) {mapping_locs = [{id = 8 : i32, resource = "tile", time_step = 8 : i32, x = 0 : i32, y = 2 : i32}]} : (!neura.data<f32, i1>) -> ()
-// MAPPING-NEXT: }
+// MAPPING:   func.func @loop_test() -> f32 attributes {CompiledII = 6 : i32, RecMII = 4 : i32, ResMII = 2 : i32, accelerator = "neura"} {
+// MAPPING-NEXT:     %0 = "neura.constant"() <{predicate = true, value = 10 : i64}> {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 0 : i32, x = 2 : i32, y = 2 : i32}]} : () -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %1 = "neura.data_mov"(%0) {mapping_locs = []} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %2 = "neura.grant_once"(%1) {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 1 : i32, x = 2 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %3 = "neura.constant"() <{predicate = true, value = 0 : i64}> {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 0 : i32, x = 2 : i32, y = 1 : i32}]} : () -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %4 = "neura.data_mov"(%3) {mapping_locs = [{id = 17 : i32, resource = "link", time_step = 0 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %5 = "neura.grant_once"(%4) {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 1 : i32, x = 1 : i32, y = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %6 = "neura.constant"() <{predicate = true, value = 1 : i64}> {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 0 : i32, x = 1 : i32, y = 2 : i32}]} : () -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %7 = "neura.data_mov"(%6) {mapping_locs = []} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %8 = "neura.grant_once"(%7) {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 1 : i32, x = 1 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %9 = "neura.constant"() <{predicate = true, value = 3.000000e+00 : f32}> {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 0 : i32, x = 1 : i32, y = 1 : i32}]} : () -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %10 = "neura.data_mov"(%9) {mapping_locs = [{id = 14 : i32, resource = "link", time_step = 0 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %11 = "neura.grant_once"(%10) {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 1 : i32, x = 2 : i32, y = 1 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %12 = "neura.constant"() <{predicate = true, value = 0.000000e+00 : f32}> {mapping_locs = [{id = 11 : i32, resource = "tile", time_step = 0 : i32, x = 3 : i32, y = 2 : i32}]} : () -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %13 = "neura.data_mov"(%12) {mapping_locs = [{id = 35 : i32, resource = "link", time_step = 0 : i32}, {id = 31 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %14 = "neura.grant_once"(%13) {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 2 : i32, x = 1 : i32, y = 2 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %15 = neura.reserve : !neura.data<i64, i1>
+// MAPPING-NEXT:     %16 = "neura.data_mov"(%2) {mapping_locs = [{id = 33 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %17 = "neura.phi"(%15, %16) {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 2 : i32, x = 2 : i32, y = 1 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %18 = neura.reserve : !neura.data<i64, i1>
+// MAPPING-NEXT:     %19 = "neura.data_mov"(%8) {mapping_locs = [{id = 28 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %20 = "neura.phi"(%18, %19) {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 2 : i32, x = 2 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %21 = neura.reserve : !neura.data<f32, i1>
+// MAPPING-NEXT:     %22 = "neura.data_mov"(%11) {mapping_locs = [{id = 20 : i32, resource = "link", time_step = 1 : i32}, {id = 40 : i32, resource = "register", time_step = 2 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %23 = "neura.phi"(%21, %22) {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 3 : i32, x = 2 : i32, y = 2 : i32}]} : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %24 = neura.reserve : !neura.data<f32, i1>
+// MAPPING-NEXT:     %25 = "neura.data_mov"(%14) {mapping_locs = []} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %26 = "neura.phi"(%24, %25) {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 3 : i32, x = 1 : i32, y = 2 : i32}]} : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %27 = neura.reserve : !neura.data<i64, i1>
+// MAPPING-NEXT:     %28 = "neura.data_mov"(%5) {mapping_locs = []} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %29 = "neura.phi"(%27, %28) {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 2 : i32, x = 1 : i32, y = 1 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %30 = "neura.data_mov"(%26) {mapping_locs = [{id = 28 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %31 = "neura.data_mov"(%23) {mapping_locs = []} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %32 = "neura.fadd"(%30, %31) {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 4 : i32, x = 2 : i32, y = 2 : i32}]} : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %33 = "neura.data_mov"(%29) {mapping_locs = [{id = 14 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %34 = "neura.data_mov"(%20) {mapping_locs = [{id = 33 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %35 = "neura.add"(%33, %34) {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 3 : i32, x = 2 : i32, y = 1 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %36 = "neura.data_mov"(%35) {mapping_locs = [{id = 17 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %37 = "neura.data_mov"(%17) {mapping_locs = [{id = 17 : i32, resource = "link", time_step = 2 : i32}, {id = 20 : i32, resource = "register", time_step = 3 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %38 = "neura.icmp"(%36, %37) <{cmpType = "slt"}> {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 4 : i32, x = 1 : i32, y = 1 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %39 = "neura.data_mov"(%35) {mapping_locs = [{id = 19 : i32, resource = "link", time_step = 3 : i32}, {id = 5 : i32, resource = "link", time_step = 4 : i32}, {id = 4 : i32, resource = "link", time_step = 5 : i32}, {id = 20 : i32, resource = "register", time_step = 6 : i32}, {id = 20 : i32, resource = "register", time_step = 7 : i32}, {id = 20 : i32, resource = "register", time_step = 8 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %40 = "neura.data_mov"(%38) {mapping_locs = []} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %41 = neura.grant_predicate %39, %40 {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 9 : i32, x = 1 : i32, y = 1 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// MAPPING-NEXT:     neura.ctrl_mov %41 -> %27 {mapping_locs = []} : !neura.data<i64, i1> !neura.data<i64, i1>
+// MAPPING-NEXT:     %42 = "neura.data_mov"(%32) {mapping_locs = [{id = 31 : i32, resource = "link", time_step = 4 : i32}, {id = 27 : i32, resource = "link", time_step = 5 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %43 = "neura.data_mov"(%38) {mapping_locs = [{id = 13 : i32, resource = "link", time_step = 4 : i32}, {id = 12 : i32, resource = "link", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %44 = neura.grant_predicate %42, %43 {mapping_locs = [{id = 8 : i32, resource = "tile", time_step = 6 : i32, x = 0 : i32, y = 2 : i32}]} : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// MAPPING-NEXT:     neura.ctrl_mov %44 -> %24 {mapping_locs = [{id = 24 : i32, resource = "link", time_step = 6 : i32}, {id = 36 : i32, resource = "register", time_step = 7 : i32}, {id = 36 : i32, resource = "register", time_step = 8 : i32}]} : !neura.data<f32, i1> !neura.data<f32, i1>
+// MAPPING-NEXT:     %45 = "neura.data_mov"(%11) {mapping_locs = [{id = 19 : i32, resource = "link", time_step = 1 : i32}, {id = 5 : i32, resource = "link", time_step = 2 : i32}, {id = 4 : i32, resource = "register", time_step = 3 : i32}, {id = 4 : i32, resource = "register", time_step = 4 : i32}, {id = 4 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %46 = "neura.data_mov"(%38) {mapping_locs = [{id = 15 : i32, resource = "link", time_step = 4 : i32}, {id = 5 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %47 = neura.grant_predicate %45, %46 {mapping_locs = [{id = 1 : i32, resource = "tile", time_step = 6 : i32, x = 1 : i32, y = 0 : i32}]} : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// MAPPING-NEXT:     neura.ctrl_mov %47 -> %21 {mapping_locs = [{id = 3 : i32, resource = "link", time_step = 6 : i32}, {id = 7 : i32, resource = "link", time_step = 7 : i32}, {id = 20 : i32, resource = "link", time_step = 8 : i32}]} : !neura.data<f32, i1> !neura.data<f32, i1>
+// MAPPING-NEXT:     %48 = "neura.data_mov"(%8) {mapping_locs = [{id = 29 : i32, resource = "link", time_step = 1 : i32}, {id = 15 : i32, resource = "link", time_step = 2 : i32}, {id = 3 : i32, resource = "link", time_step = 3 : i32}, {id = 7 : i32, resource = "link", time_step = 4 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %49 = "neura.data_mov"(%38) {mapping_locs = [{id = 14 : i32, resource = "link", time_step = 4 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %50 = neura.grant_predicate %48, %49 {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 5 : i32, x = 2 : i32, y = 1 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// MAPPING-NEXT:     neura.ctrl_mov %50 -> %18 {mapping_locs = [{id = 20 : i32, resource = "link", time_step = 5 : i32}, {id = 40 : i32, resource = "register", time_step = 6 : i32}, {id = 40 : i32, resource = "register", time_step = 7 : i32}]} : !neura.data<i64, i1> !neura.data<i64, i1>
+// MAPPING-NEXT:     %51 = "neura.data_mov"(%2) {mapping_locs = [{id = 34 : i32, resource = "link", time_step = 1 : i32}, {id = 43 : i32, resource = "link", time_step = 2 : i32}, {id = 42 : i32, resource = "link", time_step = 3 : i32}, {id = 36 : i32, resource = "register", time_step = 4 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %52 = "neura.data_mov"(%38) {mapping_locs = [{id = 16 : i32, resource = "link", time_step = 4 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %53 = neura.grant_predicate %51, %52 {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 5 : i32, x = 1 : i32, y = 2 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// MAPPING-NEXT:     neura.ctrl_mov %53 -> %15 {mapping_locs = [{id = 28 : i32, resource = "link", time_step = 5 : i32}, {id = 33 : i32, resource = "link", time_step = 6 : i32}, {id = 24 : i32, resource = "register", time_step = 7 : i32}]} : !neura.data<i64, i1> !neura.data<i64, i1>
+// MAPPING-NEXT:     %54 = "neura.data_mov"(%38) {mapping_locs = []} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %55 = "neura.not"(%54) {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 5 : i32, x = 1 : i32, y = 1 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %56 = "neura.data_mov"(%32) {mapping_locs = [{id = 33 : i32, resource = "link", time_step = 4 : i32}, {id = 17 : i32, resource = "link", time_step = 5 : i32}, {id = 13 : i32, resource = "link", time_step = 6 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %57 = "neura.data_mov"(%55) {mapping_locs = [{id = 13 : i32, resource = "link", time_step = 5 : i32}, {id = 16 : i32, resource = "register", time_step = 6 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %58 = neura.grant_predicate %56, %57 {mapping_locs = [{id = 4 : i32, resource = "tile", time_step = 7 : i32, x = 0 : i32, y = 1 : i32}]} : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %59 = "neura.data_mov"(%58) {mapping_locs = [{id = 12 : i32, resource = "link", time_step = 7 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     "neura.return"(%59) {mapping_locs = [{id = 8 : i32, resource = "tile", time_step = 8 : i32, x = 0 : i32, y = 2 : i32}]} : (!neura.data<f32, i1>) -> ()
+// MAPPING-NEXT:   }
 
 // INST:        "name": "neura.fadd",
 // INST-NEXT:   "operands": [

--- a/test/neura/ctrl/nested_branch.mlir
+++ b/test/neura/ctrl/nested_branch.mlir
@@ -60,40 +60,38 @@ func.func @complex_test(%in: i64) -> f32 {
 // CHECK-NEXT:   "neura.return"(%17) : (!neura.data<f32, i1>) -> ()
 // CHECK-NEXT: }
 
-// CTRL2DATA: func.func @complex_test(%arg0: i64) -> f32 attributes {accelerator = "neura"} {
+// CTRL2DATA:     func.func @complex_test(%arg0: i64) -> f32 attributes {accelerator = "neura"} {
 // CTRL2DATA-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %1 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 1.000000e+00 : f32}> : () -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %3 = "neura.grant_always"(%2) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %4 = "neura.grant_once"(%2) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %5 = "neura.constant"() <{predicate = true, value = 2.000000e+00 : f32}> : () -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %6 = "neura.grant_always"(%5) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %7 = "neura.grant_once"(%5) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %8 = "neura.constant"() <{predicate = true, value = 3.000000e+00 : f32}> : () -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %3 = "neura.grant_once"(%2) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %4 = "neura.constant"() <{predicate = true, value = 2.000000e+00 : f32}> : () -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %5 = "neura.grant_once"(%4) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %6 = "neura.constant"() <{predicate = true, value = 3.000000e+00 : f32}> : () -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %7 = "neura.grant_once"(%6) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %8 = "neura.constant"() <{predicate = true, value = 4.000000e+00 : f32}> : () -> !neura.data<f32, i1>
 // CTRL2DATA-NEXT:     %9 = "neura.grant_once"(%8) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %10 = "neura.constant"() <{predicate = true, value = 4.000000e+00 : f32}> : () -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %11 = "neura.grant_once"(%10) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %12 = "neura.icmp"(%0, %1) <{cmpType = "eq"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %13 = "neura.grant_once"(%12) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %14 = neura.grant_predicate %9, %13 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %15 = neura.grant_predicate %11, %13 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %16 = "neura.not"(%13) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %17 = neura.grant_predicate %4, %16 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %18 = neura.grant_predicate %7, %16 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %10 = "neura.icmp"(%0, %1) <{cmpType = "eq"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %11 = "neura.grant_once"(%10) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %12 = neura.grant_predicate %7, %11 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %13 = neura.grant_predicate %9, %11 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %14 = "neura.not"(%11) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %15 = neura.grant_predicate %3, %14 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %16 = neura.grant_predicate %5, %14 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %17 = neura.reserve : !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %18 = "neura.phi"(%17, %16) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
 // CTRL2DATA-NEXT:     %19 = neura.reserve : !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %20 = "neura.phi"(%19, %18) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %21 = neura.reserve : !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %22 = "neura.phi"(%21, %17) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %23 = "neura.fcmp"(%22, %20) <{cmpType = "olt"}> : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %24 = neura.grant_predicate %22, %23 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %25 = neura.grant_predicate %4, %23 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %7, %23 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %27 = "neura.not"(%23) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %28 = neura.grant_predicate %22, %27 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %29 = "neura.fadd"(%24, %25) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %29 -> %21 : !neura.data<f32, i1> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %26 -> %19 : !neura.data<f32, i1> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %30 = "neura.fmul"(%14, %15) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %31 = "neura.phi"(%28, %30) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     "neura.return"(%31) : (!neura.data<f32, i1>) -> ()
+// CTRL2DATA-NEXT:     %20 = "neura.phi"(%19, %15) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %21 = "neura.fcmp"(%20, %18) <{cmpType = "olt"}> : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %22 = neura.grant_predicate %20, %21 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %23 = neura.grant_predicate %3, %21 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %24 = neura.grant_predicate %5, %21 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %25 = "neura.not"(%21) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %20, %25 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %27 = "neura.fadd"(%22, %23) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %27 -> %19 : !neura.data<f32, i1> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %24 -> %17 : !neura.data<f32, i1> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %28 = "neura.fmul"(%12, %13) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %29 = "neura.phi"(%26, %28) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     "neura.return"(%29) : (!neura.data<f32, i1>) -> ()
 // CTRL2DATA-NEXT:   }

--- a/test/neura/for_loop/test.mlir
+++ b/test/neura/for_loop/test.mlir
@@ -55,172 +55,157 @@
 // CHECK-NEXT:   }
 
 // Verifies the neura ops are generated. And fusion happens.
-// CHECK-FUSED: llvm.func local_unnamed_addr @_Z6kernelPfS_S_(%arg0: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}, %arg1: !llvm.ptr {llvm.nocapture, llvm.noundef}, %arg2: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}) attributes {accelerator = "neura", memory_effects = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = none>, no_unwind, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], target_cpu = "x86-64", target_features = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, tune_cpu = "generic"} {
-// CHECK-FUSED:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %1 = "neura.grant_always"(%0) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %2 = "neura.grant_once"(%0) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %3 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %4 = "neura.grant_always"(%3) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %5 = "neura.grant_once"(%3) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %6 = "neura.constant"() <{predicate = true, value = "%arg2"}> : () -> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %7 = "neura.grant_always"(%6) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %8 = "neura.grant_once"(%6) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %9 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     %10 = "neura.grant_once"(%9) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     %11 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     %12 = "neura.grant_always"(%11) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     %13 = "neura.grant_once"(%11) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     %14 = "neura.constant"() <{predicate = true, value = 32 : i64}> : () -> !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     %15 = "neura.grant_always"(%14) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     %16 = "neura.grant_once"(%14) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     %17 = "neura.load"(%3) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<f32, i1>
-// CHECK-FUSED-NEXT:     %18 = "neura.grant_once"(%17) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-FUSED-NEXT:     %19 = neura.reserve : !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     %20 = "neura.phi"(%19, %16) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     %21 = neura.reserve : !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     %22 = "neura.phi"(%21, %13) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     %23 = neura.reserve : !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %24 = "neura.phi"(%23, %5) : (!neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %25 = neura.reserve : !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %26 = "neura.phi"(%25, %8) : (!neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %27 = neura.reserve : !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %28 = "neura.phi"(%27, %2) : (!neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %29 = neura.reserve : !neura.data<f32, i1>
-// CHECK-FUSED-NEXT:     %30 = "neura.phi"(%29, %18) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-FUSED-NEXT:     %31 = neura.reserve : !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     %32 = "neura.phi"(%31, %10) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     %33 = "neura.gep"(%28, %32) : (!neura.data<!llvm.ptr, i1>, !neura.data<i64, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %34 = "neura.load"(%33) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<f32, i1>
-// CHECK-FUSED-NEXT:     %35 = "neura.gep"(%26, %32) : (!neura.data<!llvm.ptr, i1>, !neura.data<i64, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %36 = "neura.load"(%35) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<f32, i1>
-// CHECK-FUSED-NEXT:     %37 = "neura.fmul_fadd"(%34, %36, %30) : (!neura.data<f32, i1>, !neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-FUSED-NEXT:     "neura.store"(%37, %24) : (!neura.data<f32, i1>, !neura.data<!llvm.ptr, i1>) -> ()
-// CHECK-FUSED-NEXT:     %38 = "neura.add"(%32, %22) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     %39 = "neura.icmp"(%38, %20) <{cmpType = "eq"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CHECK-FUSED-NEXT:     %40 = "neura.not"(%39) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CHECK-FUSED-NEXT:     %41 = neura.grant_predicate %38, %40 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     neura.ctrl_mov %41 -> %31 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     %42 = neura.grant_predicate %37, %40 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// CHECK-FUSED-NEXT:     neura.ctrl_mov %42 -> %29 : !neura.data<f32, i1> !neura.data<f32, i1>
-// CHECK-FUSED-NEXT:     %43 = neura.grant_predicate %2, %40 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     neura.ctrl_mov %43 -> %27 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %44 = neura.grant_predicate %8, %40 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     neura.ctrl_mov %44 -> %25 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %45 = neura.grant_predicate %5, %40 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     neura.ctrl_mov %45 -> %23 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %46 = neura.grant_predicate %13, %40 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     neura.ctrl_mov %46 -> %21 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     %47 = neura.grant_predicate %16, %40 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     neura.ctrl_mov %47 -> %19 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CHECK-FUSED:     llvm.func local_unnamed_addr @_Z6kernelPfS_S_(%arg0: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}, %arg1: !llvm.ptr {llvm.nocapture, llvm.noundef}, %arg2: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}) attributes {accelerator = "neura", memory_effects = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = none>, no_unwind, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], target_cpu = "x86-64", target_features = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, tune_cpu = "generic"} {
+// CHECK-FUSED-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %1 = "neura.grant_once"(%0) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %2 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %3 = "neura.grant_once"(%2) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %4 = "neura.constant"() <{predicate = true, value = "%arg2"}> : () -> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %5 = "neura.grant_once"(%4) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %6 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     %7 = "neura.grant_once"(%6) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     %8 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     %9 = "neura.grant_once"(%8) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     %10 = "neura.constant"() <{predicate = true, value = 32 : i64}> : () -> !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     %11 = "neura.grant_once"(%10) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     %12 = "neura.load"(%2) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<f32, i1>
+// CHECK-FUSED-NEXT:     %13 = "neura.grant_once"(%12) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-FUSED-NEXT:     %14 = neura.reserve : !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     %15 = "neura.phi"(%14, %11) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     %16 = neura.reserve : !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     %17 = "neura.phi"(%16, %9) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     %18 = neura.reserve : !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %19 = "neura.phi"(%18, %3) : (!neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %20 = neura.reserve : !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %21 = "neura.phi"(%20, %5) : (!neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %22 = neura.reserve : !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %23 = "neura.phi"(%22, %1) : (!neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %24 = neura.reserve : !neura.data<f32, i1>
+// CHECK-FUSED-NEXT:     %25 = "neura.phi"(%24, %13) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-FUSED-NEXT:     %26 = neura.reserve : !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     %27 = "neura.phi"(%26, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     %28 = "neura.gep"(%23, %27) : (!neura.data<!llvm.ptr, i1>, !neura.data<i64, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %29 = "neura.load"(%28) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<f32, i1>
+// CHECK-FUSED-NEXT:     %30 = "neura.gep"(%21, %27) : (!neura.data<!llvm.ptr, i1>, !neura.data<i64, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %31 = "neura.load"(%30) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<f32, i1>
+// CHECK-FUSED-NEXT:     %32 = "neura.fmul_fadd"(%29, %31, %25) : (!neura.data<f32, i1>, !neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-FUSED-NEXT:     "neura.store"(%32, %19) : (!neura.data<f32, i1>, !neura.data<!llvm.ptr, i1>) -> ()
+// CHECK-FUSED-NEXT:     %33 = "neura.add"(%27, %17) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     %34 = "neura.icmp"(%33, %15) <{cmpType = "eq"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CHECK-FUSED-NEXT:     %35 = "neura.not"(%34) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CHECK-FUSED-NEXT:     %36 = neura.grant_predicate %33, %35 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     neura.ctrl_mov %36 -> %26 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     %37 = neura.grant_predicate %32, %35 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CHECK-FUSED-NEXT:     neura.ctrl_mov %37 -> %24 : !neura.data<f32, i1> !neura.data<f32, i1>
+// CHECK-FUSED-NEXT:     %38 = neura.grant_predicate %1, %35 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     neura.ctrl_mov %38 -> %22 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %39 = neura.grant_predicate %5, %35 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     neura.ctrl_mov %39 -> %20 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %40 = neura.grant_predicate %3, %35 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     neura.ctrl_mov %40 -> %18 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %41 = neura.grant_predicate %9, %35 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     neura.ctrl_mov %41 -> %16 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     %42 = neura.grant_predicate %11, %35 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     neura.ctrl_mov %42 -> %14 : !neura.data<i64, i1> !neura.data<i64, i1>
 // CHECK-FUSED-NEXT:     "neura.return"() : () -> ()
 // CHECK-FUSED-NEXT:   }
 
-// CHECK-MOV: llvm.func local_unnamed_addr @_Z6kernelPfS_S_(%arg0: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}, %arg1: !llvm.ptr {llvm.nocapture, llvm.noundef}, %arg2: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}) attributes {accelerator = "neura", memory_effects = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = none>, no_unwind, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], target_cpu = "x86-64", target_features = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, tune_cpu = "generic"} {
-// CHECK-MOV-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %1 = "neura.data_mov"(%0) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %2 = "neura.grant_always"(%1) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %3 = "neura.data_mov"(%0) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %4 = "neura.grant_once"(%3) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %5 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %6 = "neura.data_mov"(%5) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %7 = "neura.grant_always"(%6) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %8 = "neura.data_mov"(%5) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %9 = "neura.grant_once"(%8) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %10 = "neura.constant"() <{predicate = true, value = "%arg2"}> : () -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %11 = "neura.data_mov"(%10) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %12 = "neura.grant_always"(%11) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %13 = "neura.data_mov"(%10) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %14 = "neura.grant_once"(%13) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %15 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %16 = "neura.data_mov"(%15) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %17 = "neura.grant_once"(%16) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %18 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %19 = "neura.data_mov"(%18) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %20 = "neura.grant_always"(%19) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %21 = "neura.data_mov"(%18) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %22 = "neura.grant_once"(%21) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %23 = "neura.constant"() <{predicate = true, value = 32 : i64}> : () -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %24 = "neura.data_mov"(%23) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %25 = "neura.grant_always"(%24) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %26 = "neura.data_mov"(%23) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %27 = "neura.grant_once"(%26) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %28 = "neura.data_mov"(%5) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %29 = "neura.load"(%28) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:     %30 = "neura.data_mov"(%29) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:     %31 = "neura.grant_once"(%30) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:     %32 = neura.reserve : !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %33 = "neura.data_mov"(%27) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %34 = "neura.phi"(%32, %33) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %35 = neura.reserve : !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %36 = "neura.data_mov"(%22) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %37 = "neura.phi"(%35, %36) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %38 = neura.reserve : !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %39 = "neura.data_mov"(%9) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %40 = "neura.phi"(%38, %39) : (!neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %41 = neura.reserve : !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %42 = "neura.data_mov"(%14) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %43 = "neura.phi"(%41, %42) : (!neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %44 = neura.reserve : !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %45 = "neura.data_mov"(%4) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %46 = "neura.phi"(%44, %45) : (!neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %47 = neura.reserve : !neura.data<f32, i1>
-// CHECK-MOV-NEXT:     %48 = "neura.data_mov"(%31) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:     %49 = "neura.phi"(%47, %48) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:     %50 = neura.reserve : !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %51 = "neura.data_mov"(%17) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %52 = "neura.phi"(%50, %51) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %53 = "neura.data_mov"(%46) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %54 = "neura.data_mov"(%52) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %55 = "neura.gep"(%53, %54) : (!neura.data<!llvm.ptr, i1>, !neura.data<i64, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %56 = "neura.data_mov"(%55) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %57 = "neura.load"(%56) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:     %58 = "neura.data_mov"(%43) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %59 = "neura.data_mov"(%52) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %60 = "neura.gep"(%58, %59) : (!neura.data<!llvm.ptr, i1>, !neura.data<i64, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %61 = "neura.data_mov"(%60) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %62 = "neura.load"(%61) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:     %63 = "neura.data_mov"(%57) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:     %64 = "neura.data_mov"(%62) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:     %65 = "neura.data_mov"(%49) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:     %66 = "neura.fmul_fadd"(%63, %64, %65) : (!neura.data<f32, i1>, !neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:     %67 = "neura.data_mov"(%66) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:     %68 = "neura.data_mov"(%40) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     "neura.store"(%67, %68) : (!neura.data<f32, i1>, !neura.data<!llvm.ptr, i1>) -> ()
-// CHECK-MOV-NEXT:     %69 = "neura.data_mov"(%52) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %70 = "neura.data_mov"(%37) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %71 = "neura.add"(%69, %70) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %72 = "neura.data_mov"(%71) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %73 = "neura.data_mov"(%34) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %74 = "neura.icmp"(%72, %73) <{cmpType = "eq"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:     %75 = "neura.data_mov"(%74) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:     %76 = "neura.not"(%75) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:     %77 = "neura.data_mov"(%71) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %78 = "neura.data_mov"(%76) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:     %79 = neura.grant_predicate %77, %78 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     neura.ctrl_mov %79 -> %50 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %80 = "neura.data_mov"(%66) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:     %81 = "neura.data_mov"(%76) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:     %82 = neura.grant_predicate %80, %81 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:     neura.ctrl_mov %82 -> %47 : !neura.data<f32, i1> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:     %83 = "neura.data_mov"(%4) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %84 = "neura.data_mov"(%76) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:     %85 = neura.grant_predicate %83, %84 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     neura.ctrl_mov %85 -> %44 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %86 = "neura.data_mov"(%14) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %87 = "neura.data_mov"(%76) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:     %88 = neura.grant_predicate %86, %87 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     neura.ctrl_mov %88 -> %41 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %89 = "neura.data_mov"(%9) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %90 = "neura.data_mov"(%76) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:     %91 = neura.grant_predicate %89, %90 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     neura.ctrl_mov %91 -> %38 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:     %92 = "neura.data_mov"(%22) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %93 = "neura.data_mov"(%76) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:     %94 = neura.grant_predicate %92, %93 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     neura.ctrl_mov %94 -> %35 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %95 = "neura.data_mov"(%27) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     %96 = "neura.data_mov"(%76) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:     %97 = neura.grant_predicate %95, %96 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     neura.ctrl_mov %97 -> %32 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:     "neura.return"() : () -> ()
-// CHECK-MOV-NEXT:   }
+// CHECK-MOV:     llvm.func local_unnamed_addr @_Z6kernelPfS_S_(%arg0: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}, %arg1: !llvm.ptr {llvm.nocapture, llvm.noundef}, %arg2: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}) attributes {accelerator = "neura", memory_effects = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = none>, no_unwind, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], target_cpu = "x86-64", target_features = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, tune_cpu = "generic"} {
+// CHECK-MOV-NEXT:         %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %1 = "neura.data_mov"(%0) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %2 = "neura.grant_once"(%1) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %3 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %4 = "neura.data_mov"(%3) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %5 = "neura.grant_once"(%4) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %6 = "neura.constant"() <{predicate = true, value = "%arg2"}> : () -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %7 = "neura.data_mov"(%6) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %8 = "neura.grant_once"(%7) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %9 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %10 = "neura.data_mov"(%9) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %11 = "neura.grant_once"(%10) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %12 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %13 = "neura.data_mov"(%12) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %14 = "neura.grant_once"(%13) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %15 = "neura.constant"() <{predicate = true, value = 32 : i64}> : () -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %16 = "neura.data_mov"(%15) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %17 = "neura.grant_once"(%16) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %18 = "neura.data_mov"(%3) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %19 = "neura.load"(%18) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:         %20 = "neura.data_mov"(%19) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:         %21 = "neura.grant_once"(%20) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:         %22 = neura.reserve : !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %23 = "neura.data_mov"(%17) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %24 = "neura.phi"(%22, %23) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %25 = neura.reserve : !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %26 = "neura.data_mov"(%14) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %27 = "neura.phi"(%25, %26) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %28 = neura.reserve : !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %29 = "neura.data_mov"(%5) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %30 = "neura.phi"(%28, %29) : (!neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %31 = neura.reserve : !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %32 = "neura.data_mov"(%8) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %33 = "neura.phi"(%31, %32) : (!neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %34 = neura.reserve : !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %35 = "neura.data_mov"(%2) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %36 = "neura.phi"(%34, %35) : (!neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %37 = neura.reserve : !neura.data<f32, i1>
+// CHECK-MOV-NEXT:         %38 = "neura.data_mov"(%21) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:         %39 = "neura.phi"(%37, %38) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:         %40 = neura.reserve : !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %41 = "neura.data_mov"(%11) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %42 = "neura.phi"(%40, %41) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %43 = "neura.data_mov"(%36) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %44 = "neura.data_mov"(%42) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %45 = "neura.gep"(%43, %44) : (!neura.data<!llvm.ptr, i1>, !neura.data<i64, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %46 = "neura.data_mov"(%45) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %47 = "neura.load"(%46) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:         %48 = "neura.data_mov"(%33) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %49 = "neura.data_mov"(%42) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %50 = "neura.gep"(%48, %49) : (!neura.data<!llvm.ptr, i1>, !neura.data<i64, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %51 = "neura.data_mov"(%50) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %52 = "neura.load"(%51) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:         %53 = "neura.data_mov"(%47) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:         %54 = "neura.data_mov"(%52) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:         %55 = "neura.data_mov"(%39) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:         %56 = "neura.fmul_fadd"(%53, %54, %55) : (!neura.data<f32, i1>, !neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:         %57 = "neura.data_mov"(%56) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:         %58 = "neura.data_mov"(%30) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         "neura.store"(%57, %58) : (!neura.data<f32, i1>, !neura.data<!llvm.ptr, i1>) -> ()
+// CHECK-MOV-NEXT:         %59 = "neura.data_mov"(%42) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %60 = "neura.data_mov"(%27) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %61 = "neura.add"(%59, %60) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %62 = "neura.data_mov"(%61) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %63 = "neura.data_mov"(%24) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %64 = "neura.icmp"(%62, %63) <{cmpType = "eq"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:         %65 = "neura.data_mov"(%64) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:         %66 = "neura.not"(%65) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:         %67 = "neura.data_mov"(%61) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %68 = "neura.data_mov"(%66) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:         %69 = neura.grant_predicate %67, %68 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         neura.ctrl_mov %69 -> %40 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %70 = "neura.data_mov"(%56) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:         %71 = "neura.data_mov"(%66) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:         %72 = neura.grant_predicate %70, %71 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:         neura.ctrl_mov %72 -> %37 : !neura.data<f32, i1> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:         %73 = "neura.data_mov"(%2) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %74 = "neura.data_mov"(%66) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:         %75 = neura.grant_predicate %73, %74 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         neura.ctrl_mov %75 -> %34 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %76 = "neura.data_mov"(%8) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %77 = "neura.data_mov"(%66) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:         %78 = neura.grant_predicate %76, %77 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         neura.ctrl_mov %78 -> %31 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %79 = "neura.data_mov"(%5) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %80 = "neura.data_mov"(%66) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:         %81 = neura.grant_predicate %79, %80 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         neura.ctrl_mov %81 -> %28 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:         %82 = "neura.data_mov"(%14) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %83 = "neura.data_mov"(%66) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:         %84 = neura.grant_predicate %82, %83 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         neura.ctrl_mov %84 -> %25 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %85 = "neura.data_mov"(%17) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         %86 = "neura.data_mov"(%66) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:         %87 = neura.grant_predicate %85, %86 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         neura.ctrl_mov %87 -> %22 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:         "neura.return"() : () -> ()
+// CHECK-MOV-NEXT:       }


### PR DESCRIPTION
In this pr:
- Remove the `grant_always` operations in `--transform-ctrl-to-data-pass`
- After removing the `grant_always`, we can achive `CompiledII = 6 : i32, RecMII = 4 : i32, ResMII = 2 : i32` for `branch_for.mlir` (previous compiledII=7) and `CompiledII = 3 : i32, RecMII = 3 : i32, ResMII = 2 : i32` for `simpleloop.mlir` (previous compiledII=5).