### PR TITLE
Fix the bug in canonicalize-live-in pass

### DIFF
--- a/lib/NeuraDialect/Transforms/CanonicalizeLiveInPass.cpp
+++ b/lib/NeuraDialect/Transforms/CanonicalizeLiveInPass.cpp
@@ -139,9 +139,7 @@ LogicalResult promoteLiveInValuesToBlockArgs(Region &region) {
         }
 
         SetVector<Value> &succ_live_ins = succ_live_in_iter->second;
-        SetVector<Value> &block_live_ins = all_live_ins[&current_block];
-
-        unsigned old_block_live_in_size = block_live_ins.size();
+        SetVector<Value> &current_live_ins = all_live_ins[&current_block];
 
         // Checks if the live-in value in successor block is defined in the
         // current block.
@@ -158,11 +156,12 @@ LogicalResult promoteLiveInValuesToBlockArgs(Region &region) {
             }
           }
 
-          block_live_ins.insert(live_in);
-        }
-
-        if (block_live_ins.size() > old_block_live_in_size) {
-          changed = true;
+          // If current live-ins do not contain the live-in value,
+          // we add it to the current live-ins.
+          if (!current_live_ins.contains(live_in)) {
+            current_live_ins.insert(live_in);
+            changed = true;
+          }
         }
       }
     }

--- a/lib/NeuraDialect/Transforms/CanonicalizeLiveInPass.cpp
+++ b/lib/NeuraDialect/Transforms/CanonicalizeLiveInPass.cpp
@@ -4,14 +4,12 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Block.h"
 #include "mlir/IR/Operation.h"
-#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Region.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Pass/Pass.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "llvm/ADT/MapVector.h"
-#include "llvm/Support/Casting.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/Support/raw_ostream.h"
+#include <cassert>
 #include <string>
 
 using namespace mlir;
@@ -49,125 +47,211 @@ LogicalResult promoteLiveInValuesToBlockArgs(Region &region) {
   if (region.empty()) {
     return success();
   }
+  // Collects direct live-in values for each block in the region.
+  // Without considering the transitive dependencies.
+  DenseMap<Block *, SetVector<Value>> direct_live_ins;
 
+  Block &entry_block = region.front();
+  // Initializes the direct live-ins for each block.
   for (Block &block : region.getBlocks()) {
-    // Skips the entry block.
-    if (&block == &region.front())
+    if (&block == &entry_block) {
       continue;
+    }
 
-    // Identifies all the live-in values in the block.
-    llvm::SetVector<Value> live_ins;
-
-    // Iterates over each operation in the block and its operands.
+    SetVector<Value> live_ins;
     for (Operation &op : block.getOperations()) {
       for (Value operand : op.getOperands()) {
-        // If the operand is not a block argument and is defined outside the
-        // current block, it is a live-in value.
-        if (!dyn_cast<BlockArgument>(operand)) {
-          Operation *def_op = operand.getDefiningOp();
-          if (def_op && def_op->getBlock() != &block) {
+        // If the operand is defined in another block, it is a live-in value.
+        if (auto blockArg = dyn_cast<BlockArgument>(operand)) {
+          if (blockArg.getOwner() != &block) {
             live_ins.insert(operand);
           }
-        } else if (dyn_cast<BlockArgument>(operand).getOwner() != &block) {
-          // If it is a block argument but defined in another block,
-          // it is also considered a live-in value.
-          live_ins.insert(operand);
+        } else {
+          Operation *defOp = operand.getDefiningOp();
+          if (defOp && defOp->getBlock() != &block) {
+            live_ins.insert(operand);
+          }
         }
       }
     }
 
-    if (live_ins.empty())
-      continue;
+    if (!live_ins.empty()) {
+      direct_live_ins[&block] = live_ins;
+    }
+  }
 
-    // Adds new block arguments for each live-in value.
-    unsigned original_num_args = block.getNumArguments();
+  // If we update a branch or conditional branch, we may introduce new live-ins
+  // for a block. So we need to propagate live-in values until a fixed point is
+  // reached.
+  DenseMap<Block *, SetVector<Value>> all_live_ins = direct_live_ins;
+  bool changed = true;
+
+  while (changed) {
+    changed = false;
+
+    for (Block &block : region.getBlocks()) {
+      if (&block == &region.front()) {
+        continue;
+      }
+
+      // Checks if the block has successors and if it has any live-ins.
+      for (Block *succ_block : block.getSuccessors()) {
+        auto succ_live_in_iter = all_live_ins.find(succ_block);
+        if (succ_live_in_iter == all_live_ins.end()) {
+          continue;
+        }
+
+        SetVector<Value> &succ_live_ins = succ_live_in_iter->second;
+        SetVector<Value> &block_live_ins = all_live_ins[&block];
+
+        unsigned old_block_live_in_size = block_live_ins.size();
+
+        // Checks if the live-in value in successor block is defined in the
+        // current block.
+        for (Value live_in : succ_live_ins) {
+          // If it is defined in the current block, we skip it.
+          if (Operation *defOp = live_in.getDefiningOp()) {
+            if (defOp->getBlock() == &block) {
+              continue;
+            }
+          } else if (auto blockArg = dyn_cast<BlockArgument>(live_in)) {
+            if (blockArg.getOwner() == &block) {
+              continue;
+            }
+          }
+
+          block_live_ins.insert(live_in);
+        }
+
+        if (block_live_ins.size() > old_block_live_in_size) {
+          changed = true;
+        }
+      }
+    }
+  }
+
+  // llvm::errs() << "All live-ins after propagation:\n";
+  // for (auto &[block, liveIns] : all_live_ins) {
+  //   llvm::errs() << "Block: " << *block << "\nLive-ins: ";
+  //   for (Value liveIn : liveIns) {
+  //     llvm::errs() << "   " << liveIn << "\n";
+  //   }
+  //   llvm::errs() << "\n";
+  // }
+
+  // Adds all live-in values as block arguments and updates the
+  // operations that use these live-in values.
+  DenseMap<std::pair<Block *, Value>, Value> block_value_to_arg;
+  DenseMap<Block *, unsigned> original_num_args;
+
+  for (auto &[block, live_ins] : all_live_ins) {
+    original_num_args[block] = block->getNumArguments();
+
+    // Adds all live-in values as block arguments.
     for (Value value : live_ins) {
-      block.addArgument(value.getType(), value.getLoc());
+      block->addArgument(value.getType(), value.getLoc());
     }
 
-    // Creates a mapping from live-in values to the new block arguments.
-    DenseMap<Value, Value> value_to_arg;
-    for (unsigned i = 0; i < live_ins.size(); ++i) {
-      value_to_arg[live_ins[i]] = block.getArgument(original_num_args + i);
+    // Constructs a mapping from live-in values to their corresponding
+    // block arguments.
+    unsigned index = original_num_args[block];
+    for (Value value : live_ins) {
+      block_value_to_arg[{block, value}] = block->getArgument(index++);
     }
+  }
 
-    // Updates all operations in the block to use the new block arguments
-    // instead of the live-in values.
-    for (Operation &op : block.getOperations()) {
-      for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+  // Updates all operations in the region to use the new block arguments
+  // instead of the live-in values.
+  for (auto &[block, liveIns] : all_live_ins) {
+    for (Operation &op : block->getOperations()) {
+      for (unsigned i = 0; i < op.getNumOperands(); i++) {
         Value operand = op.getOperand(i);
-        auto it = value_to_arg.find(operand);
-        if (it != value_to_arg.end()) {
-          op.setOperand(i, it->second);
-        }
+        auto key = std::make_pair(block, operand);
+
+        if (block_value_to_arg.count(key))
+          op.setOperand(i, block_value_to_arg[key]);
       }
     }
+  }
 
-    // Updates the terminator of predecessor blocks to include the new block
-    // arguments.
-    for (Block *pred_block : block.getPredecessors()) {
-      Operation *pred_op = pred_block->getTerminator();
-      // Handles br operations.
-      if (auto br_op = dyn_cast<neura::Br>(pred_op)) {
-        if (br_op.getDest() == &block) {
-          // Creates a new operand list, including the original operands.
-          SmallVector<Value, 4> new_operands;
+  // Updates the terminators of predecessor blocks to use the new block
+  // arguments instead of the live-in values.
+  for (auto &[block, live_ins] : all_live_ins) {
+    for (Block *pred_block : block->getPredecessors()) {
+      Operation *term_op = pred_block->getTerminator();
 
-          for (Value operand : br_op.getOperands()) {
-            new_operands.push_back(operand);
-          }
-
-          // Adds live-in values as new operands.
+      if (auto br_op = dyn_cast<neura::Br>(term_op)) {
+        if (br_op.getDest() == block) {
+          SmallVector<Value> new_operands(br_op.getOperands().begin(),
+                                          br_op.getOperands().end());
           for (Value live_in : live_ins) {
-            new_operands.push_back(live_in);
+            Operation *def_op = live_in.getDefiningOp();
+            BlockArgument block_arg = dyn_cast<BlockArgument>(live_in);
+            if (def_op && def_op->getBlock() == pred_block) {
+              new_operands.push_back(live_in);
+            } else if (block_arg && block_arg.getOwner() == pred_block) {
+              new_operands.push_back(block_arg);
+            } else if (all_live_ins[pred_block].contains(live_in)) {
+              new_operands.push_back(block_value_to_arg[{pred_block, live_in}]);
+            } else {
+              assert(false && "Unexpected live-in value");
+            }
           }
-
-          // Creates a new branch operation with the updated operands.
           OpBuilder builder(br_op);
-          builder.create<neura::Br>(br_op.getLoc(), new_operands, &block);
-
-          // Erases the old branch operation.
+          builder.create<neura::Br>(br_op.getLoc(), new_operands, block);
           br_op.erase();
         }
-      }
-      // Handles conditional branch operations.
-      else if (auto cond_br_op = dyn_cast<neura::CondBr>(pred_op)) {
-        OpBuilder builder(cond_br_op);
+      } else if (auto cond_br_op = dyn_cast<neura::CondBr>(term_op)) {
         bool needs_update = false;
-
-        SmallVector<Value, 4> true_operands, false_operands;
-        Block *true_dest = cond_br_op.getTrueDest();
-        Block *false_dest = cond_br_op.getFalseDest();
-
-        for (Value operand : cond_br_op.getTrueArgs()) {
-          true_operands.push_back(operand);
-        }
-        for (Value operand : cond_br_op.getFalseArgs()) {
-          false_operands.push_back(operand);
-        }
-
-        // Checks if the true branch destination is the current block.
-        if (true_dest == &block) {
+        SmallVector<Value> true_operands(cond_br_op.getTrueArgs().begin(),
+                                         cond_br_op.getTrueArgs().end());
+        SmallVector<Value> false_operands(cond_br_op.getFalseArgs().begin(),
+                                          cond_br_op.getFalseArgs().end());
+        // Handles the true branch.
+        if (cond_br_op.getTrueDest() == block) {
           needs_update = true;
           for (Value live_in : live_ins) {
-            true_operands.push_back(live_in);
+            Operation *def_op = live_in.getDefiningOp();
+            BlockArgument block_arg = dyn_cast<BlockArgument>(live_in);
+            if (def_op && def_op->getBlock() == pred_block) {
+              true_operands.push_back(live_in);
+            } else if (block_arg && block_arg.getOwner() == pred_block) {
+              true_operands.push_back(block_arg);
+            } else if (all_live_ins[pred_block].contains(live_in)) {
+              true_operands.push_back(
+                  block_value_to_arg[{pred_block, live_in}]);
+            } else {
+              assert(false && "Unexpected live-in value");
+            }
           }
         }
 
-        // Checks if the false branch destination is the current block.
-        if (false_dest == &block) {
+        // Handles the false branch.
+        if (cond_br_op.getFalseDest() == block) {
           needs_update = true;
           for (Value live_in : live_ins) {
-            false_operands.push_back(live_in);
+            Operation *def_op = live_in.getDefiningOp();
+            BlockArgument block_arg = dyn_cast<BlockArgument>(live_in);
+            if (def_op && def_op->getBlock() == pred_block) {
+              false_operands.push_back(live_in);
+            } else if (block_arg && block_arg.getOwner() == pred_block) {
+              false_operands.push_back(block_arg);
+            } else if (all_live_ins[pred_block].contains(live_in)) {
+              false_operands.push_back(
+                  block_value_to_arg[{pred_block, live_in}]);
+            } else {
+              assert(false && "Unexpected live-in value");
+            }
           }
         }
 
+        // If an update is needed, create a new conditional branch operation.
         if (needs_update) {
-          // Predicated bit defaults to null.
+          OpBuilder builder(cond_br_op);
           builder.create<neura::CondBr>(
               cond_br_op.getLoc(), cond_br_op.getCondition(), nullptr,
-              true_operands, false_operands, true_dest, false_dest);
-
+              true_operands, false_operands, cond_br_op.getTrueDest(),
+              cond_br_op.getFalseDest());
           cond_br_op.erase();
         }
       }

--- a/lib/NeuraDialect/Transforms/CanonicalizeLiveInPass.cpp
+++ b/lib/NeuraDialect/Transforms/CanonicalizeLiveInPass.cpp
@@ -93,7 +93,8 @@ LogicalResult promoteLiveInValuesToBlockArgs(Region &region) {
         continue;
       }
 
-      // Checks if the block has successors and if it has any live-ins.
+      // Checks if the predecessor block has successor blocks and if they have
+      // any live-ins.
       for (Block *succ_block : pred_block.getSuccessors()) {
         auto succ_live_in_iter = all_live_ins.find(succ_block);
         if (succ_live_in_iter == all_live_ins.end()) {
@@ -106,10 +107,10 @@ LogicalResult promoteLiveInValuesToBlockArgs(Region &region) {
         unsigned old_block_live_in_size = block_live_ins.size();
 
         // Checks if the live-in value in successor block is defined in the
-        // current block.
+        // predecessor block.
         for (Value live_in : succ_live_ins) {
-          // If it is defined in the current block, that means it is not a
-          // live-in value for the block. We can skip it.
+          // If it is defined in the predecessor block, that means it is not a
+          // live-in value for the predecessor block. We can skip it.
           if (Operation *def_op = live_in.getDefiningOp()) {
             if (def_op->getBlock() == &pred_block) {
               continue;

--- a/lib/NeuraDialect/Transforms/CanonicalizeLiveInPass.cpp
+++ b/lib/NeuraDialect/Transforms/CanonicalizeLiveInPass.cpp
@@ -8,7 +8,6 @@
 #include "mlir/IR/Value.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/SetVector.h"
-#include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <string>
 
@@ -62,13 +61,13 @@ LogicalResult promoteLiveInValuesToBlockArgs(Region &region) {
     for (Operation &op : block.getOperations()) {
       for (Value operand : op.getOperands()) {
         // If the operand is defined in another block, it is a live-in value.
-        if (auto blockArg = dyn_cast<BlockArgument>(operand)) {
-          if (blockArg.getOwner() != &block) {
+        if (auto block_arg = dyn_cast<BlockArgument>(operand)) {
+          if (block_arg.getOwner() != &block) {
             live_ins.insert(operand);
           }
         } else {
-          Operation *defOp = operand.getDefiningOp();
-          if (defOp && defOp->getBlock() != &block) {
+          Operation *def_op = operand.getDefiningOp();
+          if (def_op && def_op->getBlock() != &block) {
             live_ins.insert(operand);
           }
         }
@@ -109,13 +108,14 @@ LogicalResult promoteLiveInValuesToBlockArgs(Region &region) {
         // Checks if the live-in value in successor block is defined in the
         // current block.
         for (Value live_in : succ_live_ins) {
-          // If it is defined in the current block, we skip it.
-          if (Operation *defOp = live_in.getDefiningOp()) {
-            if (defOp->getBlock() == &block) {
+          // If it is defined in the current block, that means it is not a
+          // live-in value for the block. We can skip it.
+          if (Operation *def_op = live_in.getDefiningOp()) {
+            if (def_op->getBlock() == &block) {
               continue;
             }
-          } else if (auto blockArg = dyn_cast<BlockArgument>(live_in)) {
-            if (blockArg.getOwner() == &block) {
+          } else if (auto block_arg = dyn_cast<BlockArgument>(live_in)) {
+            if (block_arg.getOwner() == &block) {
               continue;
             }
           }

--- a/lib/NeuraDialect/Transforms/MapToAcceleratorPass.cpp
+++ b/lib/NeuraDialect/Transforms/MapToAcceleratorPass.cpp
@@ -167,16 +167,10 @@ struct MapToAcceleratorPass
       } else if (!longest) {
         rec_mii = 1; // No recurrence cycles found, set MII to 1.
       }
-      // IntegerAttr rec_mii_attr =
-      //     IntegerAttr::get(IntegerType::get(func.getContext(), 32), rec_mii);
-      // func->setAttr("RecMII", rec_mii_attr);
 
       // AcceleratorConfig config{/*numTiles=*/8}; // Example
       Architecture architecture(4, 4);
       int res_mii = calculateResMii(func, architecture);
-      // IntegerAttr res_mii_attr =
-      //     IntegerAttr::get(IntegerType::get(func.getContext(), 32), res_mii);
-      // func->setAttr("ResMII", res_mii_attr);
 
       const int possibleMinII = std::max(rec_mii, res_mii);
       constexpr int maxII = 10;

--- a/lib/NeuraDialect/Transforms/TransformCtrlToDataFlowPass.cpp
+++ b/lib/NeuraDialect/Transforms/TransformCtrlToDataFlowPass.cpp
@@ -1,4 +1,3 @@
-#include "Common/AcceleratorAttrs.h"
 #include "NeuraDialect/NeuraDialect.h"
 #include "NeuraDialect/NeuraOps.h"
 #include "NeuraDialect/NeuraPasses.h"
@@ -8,16 +7,12 @@
 #include "mlir/IR/Block.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Dominance.h"
-#include "mlir/IR/Location.h"
 #include "mlir/IR/OpDefinition.h"
-#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/Support/Casting.h"
-#include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 #include <memory>
@@ -301,13 +296,22 @@ void createReserveAndPhiOps(
   // ================================================
   // Step 1: Categorizes edges into six types.
   // ================================================
-  // Type 1: Backward cond_br edges with arguments.
+  // Type 1: Backward cond_br edges with values.
   // Type 2: Backward br edges with values.
   // Type 3: Forward cond_br edges with values.
   // Type 4: Forward br edges with values.
   // Type 5: Forward cond_br edges without values.
   // Type 6: Forward br edges without values.
-  // For Backward edges without values, they can be transformed into type 1 or 2
+  // Type 7: Backward cond_br edges without values.
+  // Type 8: Backward br edges without values.
+
+  // After --canonicalize-live-in pass, all live-in values are promoted to block
+  // arguments. This means that any edge without values can now be
+  // treated as a edge with values.
+
+  // ***************************************************************************
+  // * So we only need to handle edges with values, i.e., Type 1, 2, 3, and 4. *
+  // ***************************************************************************
 
   // Uses llvm::MapVector instead of DenseMap to maintain insertion order.
   llvm::MapVector<BlockArgument, SmallVector<ControlFlowInfo::Edge *>>
@@ -350,109 +354,6 @@ void createReserveAndPhiOps(
       }
       for (BlockArgument arg : target->getArguments()) {
         forward_value_edges[arg].push_back(edge.get());
-      }
-    }
-    // Type 5 & 6: Forward cond_br/br edges without values.
-    else if (!edge->is_back_edge && edge->passed_values.empty()) {
-      if (edge->condition) {
-        // Only Type 5 needs to be processed here.
-        // If the edge has a condition, store it for later use.
-        block_conditional_edges[target].push_back(edge.get());
-      }
-    }
-  }
-
-  // ================================================
-  // Step 2: Handles Forward cond_br edges without values.
-  // ================================================
-  // Handles Type 5 edges.
-  for (auto &condition_pair : block_conditional_edges) {
-    Block *target = condition_pair.first;
-    auto &edges = condition_pair.second;
-
-    if (edges.empty()) {
-      continue;
-    }
-
-    // Collects all conditions for the target block.
-    SmallVector<Value> conditions;
-    for (ControlFlowInfo::Edge *edge : edges) {
-      Value condition = getPrecessedCondition(
-          edge->condition, edge->is_not_condition, condition_cache, builder);
-      conditions.push_back(condition);
-    }
-
-    // Unsupported case: multiple conditions for a single block.
-    // TODO: Adds support if needed.
-    if (conditions.size() > 1) {
-      llvm::errs() << "[ctrl2data] Unsupported case: multiple conditions for a "
-                      "single block: "
-                   << *target << "\n";
-      assert(false);
-    }
-
-    if (target->getArguments().empty()) {
-      // Grants predicate for all the live-in values in the target block.
-      // Uses SetVector instead of DenseSet to maintain insertion order.
-      SetVector<Value> live_in_values;
-      for (Operation &op : target->getOperations()) {
-        for (Value operand : op.getOperands()) {
-          if (operand.getDefiningOp() &&
-              operand.getDefiningOp()->getBlock() != target &&
-              !isa<neura::ReserveOp>(operand.getDefiningOp())) {
-            live_in_values.insert(operand);
-          }
-        }
-      }
-
-      // Applies grant_predicate for each live-in value.
-      for (Value live_in_value : live_in_values) {
-        // Finds the earliest use of the live-in value.
-        Operation *earliest_use = nullptr;
-        for (Operation &op : target->getOperations()) {
-          for (Value operand : op.getOperands()) {
-            if (operand == live_in_value) {
-              earliest_use = &op;
-              break;
-            }
-          }
-          if (earliest_use) {
-            break;
-          }
-        }
-
-        if (earliest_use) {
-          builder.setInsertionPoint(earliest_use);
-        } else {
-          builder.setInsertionPointToStart(target);
-        }
-
-        // Creates predicated version of the live-in value.
-        Value predicated_value = builder.create<neura::GrantPredicateOp>(
-            live_in_value.getLoc(), live_in_value.getType(), live_in_value,
-            conditions[0]);
-
-        value_to_predicated_value[live_in_value] = predicated_value;
-
-        // Replace uses of the live-in value within this block only.
-        for (OpOperand &use :
-             llvm::make_early_inc_range(live_in_value.getUses())) {
-          if (use.getOwner()->getBlock() == target &&
-              use.getOwner() != predicated_value.getDefiningOp()) {
-            use.set(predicated_value);
-          }
-        }
-      }
-    }
-  }
-
-  // Updates the passed values in edges with predicated values.
-  for (auto &edge_ptr : ctrl_info.all_edges) {
-    ControlFlowInfo::Edge *edge = edge_ptr.get();
-    for (size_t i = 0; i < edge->passed_values.size(); ++i) {
-      Value val = edge->passed_values[i];
-      if (value_to_predicated_value.count(val)) {
-        edge->passed_values[i] = value_to_predicated_value[val];
       }
     }
   }
@@ -535,7 +436,7 @@ void createReserveAndPhiOps(
       continue;
     }
 
-    // Handles the blcockargument with/without reserve seperately (different
+    // Handles the blockargument with/without reserve separately (different
     // insertion points).
     if (arg_to_reserve.count(arg)) {
       Value reserve_value = arg_to_reserve[arg];

--- a/test/affine2neura/bert/bert_node1/bert_node1.mlir
+++ b/test/affine2neura/bert/bert_node1/bert_node1.mlir
@@ -62,7 +62,7 @@ module attributes {} {
 // CHECK-NEXT: }
 
 
-// CTRL2DATA: func.func @_Z10bert_node1PA1_A1_A1_A1_A128_bPA1_A128_S1_(%arg0: memref<?x1x1x1x1x128xi8>, %arg1: memref<?x1x128x1x1x128xi8>) attributes {accelerator = "neura"} {
+// CTRL2DATA:        func.func @_Z10bert_node1PA1_A1_A1_A1_A128_bPA1_A128_S1_(%arg0: memref<?x1x1x1x1x128xi8>, %arg1: memref<?x1x128x1x1x128xi8>) attributes {accelerator = "neura"} {
 // CTRL2DATA-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
 // CTRL2DATA-NEXT:     %1 = "neura.grant_once"(%0) : (!neura.data<memref<?x1x1x1x1x128xi8>, i1>) -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
 // CTRL2DATA-NEXT:     %2 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
@@ -74,35 +74,69 @@ module attributes {} {
 // CTRL2DATA-NEXT:     %8 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %9 = "neura.grant_once"(%8) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %10 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %11 = "neura.phi"(%10, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %12 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %13 = "neura.phi"(%12, %9) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %14 = "neura.icmp"(%13, %11) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %15 = "neura.not"(%14) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %16 = neura.grant_predicate %9, %14 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %17 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %18 = "neura.phi"(%17, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %19 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %20 = "neura.phi"(%19, %16) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %21 = "neura.icmp"(%20, %18) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %22 = neura.grant_predicate %1, %21 : !neura.data<memref<?x1x1x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
-// CTRL2DATA-NEXT:     %23 = neura.grant_predicate %9, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %24 = neura.grant_predicate %20, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %25 = neura.grant_predicate %3, %21 : !neura.data<memref<?x1x128x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
-// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %13, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %27 = neura.grant_predicate %5, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %28 = neura.grant_predicate %7, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %29 = "neura.not"(%21) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %30 = neura.grant_predicate %13, %29 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %31 = neura.grant_predicate %5, %29 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %32 = neura.grant_predicate %7, %29 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %33 = neura.load_indexed %22[%23, %23, %23, %23, %23, %24 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x1x1x1x1x128xi8>, i1> : !neura.data<i8, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %33 to %25[%23, %23, %26, %23, %23, %24 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x1x128x1x1x128xi8>, i1> : !neura.data<i8, i1>
-// CTRL2DATA-NEXT:     %34 = "neura.add"(%24, %27) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %34 -> %19 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %28 -> %17 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %35 = "neura.add"(%30, %31) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %35 -> %12 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %32 -> %10 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %11 = "neura.phi"(%10, %5) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %12 = neura.reserve : !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %13 = "neura.phi"(%12, %3) : (!neura.data<memref<?x1x128x1x1x128xi8>, i1>, !neura.data<memref<?x1x128x1x1x128xi8>, i1>) -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %14 = neura.reserve : !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %15 = "neura.phi"(%14, %1) : (!neura.data<memref<?x1x1x1x1x128xi8>, i1>, !neura.data<memref<?x1x1x1x1x128xi8>, i1>) -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %16 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %17 = "neura.phi"(%16, %9) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %18 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %19 = "neura.phi"(%18, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %20 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %21 = "neura.phi"(%20, %9) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %22 = "neura.icmp"(%21, %19) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %23 = neura.grant_predicate %17, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %24 = neura.grant_predicate %19, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %25 = neura.grant_predicate %15, %22 : !neura.data<memref<?x1x1x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %13, %22 : !neura.data<memref<?x1x128x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %27 = neura.grant_predicate %21, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %28 = neura.grant_predicate %11, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %29 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %30 = "neura.phi"(%29, %28) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %31 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %32 = "neura.phi"(%31, %27) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %33 = neura.reserve : !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %34 = "neura.phi"(%33, %26) : (!neura.data<memref<?x1x128x1x1x128xi8>, i1>, !neura.data<memref<?x1x128x1x1x128xi8>, i1>) -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %35 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %36 = "neura.phi"(%35, %23) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %37 = neura.reserve : !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %38 = "neura.phi"(%37, %25) : (!neura.data<memref<?x1x1x1x1x128xi8>, i1>, !neura.data<memref<?x1x1x1x1x128xi8>, i1>) -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %39 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %40 = "neura.phi"(%39, %24) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %41 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %42 = "neura.phi"(%41, %23) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %43 = "neura.icmp"(%42, %40) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %44 = neura.grant_predicate %38, %43 : !neura.data<memref<?x1x1x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %45 = neura.grant_predicate %36, %43 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %46 = neura.grant_predicate %42, %43 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %47 = neura.grant_predicate %34, %43 : !neura.data<memref<?x1x128x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %48 = neura.grant_predicate %32, %43 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %49 = neura.grant_predicate %30, %43 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %50 = neura.grant_predicate %40, %43 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %51 = "neura.not"(%43) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %52 = neura.grant_predicate %32, %51 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %53 = neura.grant_predicate %30, %51 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %54 = neura.grant_predicate %40, %51 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %55 = neura.grant_predicate %36, %51 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %56 = neura.grant_predicate %38, %51 : !neura.data<memref<?x1x1x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %57 = neura.grant_predicate %34, %51 : !neura.data<memref<?x1x128x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %58 = neura.load_indexed %44[%45, %45, %45, %45, %45, %46 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x1x1x1x1x128xi8>, i1> : !neura.data<i8, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %58 to %47[%45, %45, %48, %45, %45, %46 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x1x128x1x1x128xi8>, i1> : !neura.data<i8, i1>
+// CTRL2DATA-NEXT:     %59 = "neura.add"(%46, %49) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %59 -> %41 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %50 -> %39 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %44 -> %37 : !neura.data<memref<?x1x1x1x1x128xi8>, i1> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %45 -> %35 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %47 -> %33 : !neura.data<memref<?x1x128x1x1x128xi8>, i1> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %48 -> %31 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %49 -> %29 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %60 = "neura.add"(%52, %53) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %60 -> %20 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %54 -> %18 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %55 -> %16 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %56 -> %14 : !neura.data<memref<?x1x1x1x1x128xi8>, i1> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %57 -> %12 : !neura.data<memref<?x1x128x1x1x128xi8>, i1> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %53 -> %10 : !neura.data<i64, i1> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     "neura.return"() : () -> ()
 // CTRL2DATA-NEXT:   }

--- a/test/affine2neura/bert/bert_node28/bert_node28.mlir
+++ b/test/affine2neura/bert/bert_node28/bert_node28.mlir
@@ -81,8 +81,7 @@ module attributes {} {
 // CHECK-NEXT: ^bb9:  // pred: ^bb1
 // CHECK-NEXT: "neura.return"() : () -> ()
 
-
-// CTRL2DATA:     func.func @_Z11bert_node28PA128_A768_KfPA768_S0_PA128_A768_f(%arg0: memref<?x128x768xf32>, %arg1: memref<?x768x768xf32>, %arg2: memref<?x128x768xf32>) attributes {accelerator = "neura"} {
+// CTRL2DATA:        func.func @_Z11bert_node28PA128_A768_KfPA768_S0_PA128_A768_f(%arg0: memref<?x128x768xf32>, %arg1: memref<?x768x768xf32>, %arg2: memref<?x128x768xf32>) attributes {accelerator = "neura"} {
 // CTRL2DATA-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<memref<?x128x768xf32>, i1>
 // CTRL2DATA-NEXT:     %1 = "neura.grant_once"(%0) : (!neura.data<memref<?x128x768xf32>, i1>) -> !neura.data<memref<?x128x768xf32>, i1>
 // CTRL2DATA-NEXT:     %2 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<memref<?x768x768xf32>, i1>
@@ -97,55 +96,144 @@ module attributes {} {
 // CTRL2DATA-NEXT:     %11 = "neura.grant_once"(%10) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %12 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %13 = "neura.grant_once"(%12) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %14 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %15 = "neura.phi"(%14, %11) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %16 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %17 = "neura.phi"(%16, %13) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %18 = "neura.icmp"(%17, %15) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %19 = "neura.not"(%18) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %20 = neura.grant_predicate %13, %18 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %21 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %22 = "neura.phi"(%21, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %23 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %24 = "neura.phi"(%23, %20) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %25 = "neura.icmp"(%24, %22) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %13, %25 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %27 = "neura.not"(%25) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %28 = neura.grant_predicate %17, %27 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %29 = neura.grant_predicate %9, %27 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %30 = neura.grant_predicate %11, %27 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %31 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %32 = "neura.phi"(%31, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %33 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %34 = "neura.phi"(%33, %26) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %35 = "neura.icmp"(%34, %32) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %36 = neura.grant_predicate %1, %35 : !neura.data<memref<?x128x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128x768xf32>, i1>
-// CTRL2DATA-NEXT:     %37 = neura.grant_predicate %13, %35 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %38 = neura.grant_predicate %17, %35 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %39 = neura.grant_predicate %34, %35 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %40 = neura.grant_predicate %3, %35 : !neura.data<memref<?x768x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x768x768xf32>, i1>
-// CTRL2DATA-NEXT:     %41 = neura.grant_predicate %24, %35 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %42 = neura.grant_predicate %5, %35 : !neura.data<memref<?x128x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128x768xf32>, i1>
-// CTRL2DATA-NEXT:     %43 = neura.grant_predicate %9, %35 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %44 = neura.grant_predicate %7, %35 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %45 = "neura.not"(%35) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %46 = neura.grant_predicate %24, %45 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %47 = neura.grant_predicate %9, %45 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %48 = neura.grant_predicate %7, %45 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %49 = neura.load_indexed %36[%37, %38, %39 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128x768xf32>, i1> : !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %50 = neura.load_indexed %40[%37, %39, %41 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x768x768xf32>, i1> : !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %51 = neura.load_indexed %42[%37, %38, %41 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128x768xf32>, i1> : !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %52 = "neura.fmul"(%49, %50) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %53 = "neura.fadd"(%51, %52) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %53 to %42[%37, %38, %41 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128x768xf32>, i1> : !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %54 = "neura.add"(%39, %43) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %54 -> %33 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %44 -> %31 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %55 = "neura.add"(%46, %47) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %55 -> %23 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %48 -> %21 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %56 = "neura.add"(%28, %29) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %56 -> %16 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %30 -> %14 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %14 = neura.reserve : !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %15 = "neura.phi"(%14, %5) : (!neura.data<memref<?x128x768xf32>, i1>, !neura.data<memref<?x128x768xf32>, i1>) -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %16 = neura.reserve : !neura.data<memref<?x768x768xf32>, i1>
+// CTRL2DATA-NEXT:     %17 = "neura.phi"(%16, %3) : (!neura.data<memref<?x768x768xf32>, i1>, !neura.data<memref<?x768x768xf32>, i1>) -> !neura.data<memref<?x768x768xf32>, i1>
+// CTRL2DATA-NEXT:     %18 = neura.reserve : !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %19 = "neura.phi"(%18, %1) : (!neura.data<memref<?x128x768xf32>, i1>, !neura.data<memref<?x128x768xf32>, i1>) -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %20 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %21 = "neura.phi"(%20, %9) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %22 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %23 = "neura.phi"(%22, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %24 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %25 = "neura.phi"(%24, %13) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %26 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %27 = "neura.phi"(%26, %11) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %28 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %29 = "neura.phi"(%28, %13) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %30 = "neura.icmp"(%29, %27) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %31 = neura.grant_predicate %25, %30 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %32 = neura.grant_predicate %23, %30 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %33 = neura.grant_predicate %29, %30 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %34 = neura.grant_predicate %21, %30 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %35 = neura.grant_predicate %27, %30 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %36 = neura.grant_predicate %19, %30 : !neura.data<memref<?x128x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %37 = neura.grant_predicate %17, %30 : !neura.data<memref<?x768x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x768x768xf32>, i1>
+// CTRL2DATA-NEXT:     %38 = neura.grant_predicate %15, %30 : !neura.data<memref<?x128x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %39 = neura.reserve : !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %40 = "neura.phi"(%39, %38) : (!neura.data<memref<?x128x768xf32>, i1>, !neura.data<memref<?x128x768xf32>, i1>) -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %41 = neura.reserve : !neura.data<memref<?x768x768xf32>, i1>
+// CTRL2DATA-NEXT:     %42 = "neura.phi"(%41, %37) : (!neura.data<memref<?x768x768xf32>, i1>, !neura.data<memref<?x768x768xf32>, i1>) -> !neura.data<memref<?x768x768xf32>, i1>
+// CTRL2DATA-NEXT:     %43 = neura.reserve : !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %44 = "neura.phi"(%43, %36) : (!neura.data<memref<?x128x768xf32>, i1>, !neura.data<memref<?x128x768xf32>, i1>) -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %45 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %46 = "neura.phi"(%45, %35) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %47 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %48 = "neura.phi"(%47, %34) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %49 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %50 = "neura.phi"(%49, %33) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %51 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %52 = "neura.phi"(%51, %31) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %53 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %54 = "neura.phi"(%53, %32) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %55 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %56 = "neura.phi"(%55, %31) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %57 = "neura.icmp"(%56, %54) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %58 = neura.grant_predicate %52, %57 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %59 = neura.grant_predicate %54, %57 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %60 = neura.grant_predicate %44, %57 : !neura.data<memref<?x128x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %61 = neura.grant_predicate %50, %57 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %62 = neura.grant_predicate %42, %57 : !neura.data<memref<?x768x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x768x768xf32>, i1>
+// CTRL2DATA-NEXT:     %63 = neura.grant_predicate %56, %57 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %64 = neura.grant_predicate %40, %57 : !neura.data<memref<?x128x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %65 = neura.grant_predicate %48, %57 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %66 = neura.grant_predicate %46, %57 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %67 = "neura.not"(%57) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %68 = neura.grant_predicate %50, %67 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %69 = neura.grant_predicate %48, %67 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %70 = neura.grant_predicate %46, %67 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %71 = neura.grant_predicate %52, %67 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %72 = neura.grant_predicate %54, %67 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %73 = neura.grant_predicate %44, %67 : !neura.data<memref<?x128x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %74 = neura.grant_predicate %42, %67 : !neura.data<memref<?x768x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x768x768xf32>, i1>
+// CTRL2DATA-NEXT:     %75 = neura.grant_predicate %40, %67 : !neura.data<memref<?x128x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %76 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %77 = "neura.phi"(%76, %66) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %78 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %79 = "neura.phi"(%78, %65) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %80 = neura.reserve : !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %81 = "neura.phi"(%80, %64) : (!neura.data<memref<?x128x768xf32>, i1>, !neura.data<memref<?x128x768xf32>, i1>) -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %82 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %83 = "neura.phi"(%82, %63) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %84 = neura.reserve : !neura.data<memref<?x768x768xf32>, i1>
+// CTRL2DATA-NEXT:     %85 = "neura.phi"(%84, %62) : (!neura.data<memref<?x768x768xf32>, i1>, !neura.data<memref<?x768x768xf32>, i1>) -> !neura.data<memref<?x768x768xf32>, i1>
+// CTRL2DATA-NEXT:     %86 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %87 = "neura.phi"(%86, %61) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %88 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %89 = "neura.phi"(%88, %58) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %90 = neura.reserve : !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %91 = "neura.phi"(%90, %60) : (!neura.data<memref<?x128x768xf32>, i1>, !neura.data<memref<?x128x768xf32>, i1>) -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %92 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %93 = "neura.phi"(%92, %59) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %94 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %95 = "neura.phi"(%94, %58) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %96 = "neura.icmp"(%95, %93) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %97 = neura.grant_predicate %91, %96 : !neura.data<memref<?x128x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %98 = neura.grant_predicate %89, %96 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %99 = neura.grant_predicate %87, %96 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %100 = neura.grant_predicate %95, %96 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %101 = neura.grant_predicate %85, %96 : !neura.data<memref<?x768x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x768x768xf32>, i1>
+// CTRL2DATA-NEXT:     %102 = neura.grant_predicate %83, %96 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %103 = neura.grant_predicate %81, %96 : !neura.data<memref<?x128x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %104 = neura.grant_predicate %79, %96 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %105 = neura.grant_predicate %93, %96 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %106 = neura.grant_predicate %77, %96 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %107 = "neura.not"(%96) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %108 = neura.grant_predicate %83, %107 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %109 = neura.grant_predicate %79, %107 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %110 = neura.grant_predicate %93, %107 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %111 = neura.grant_predicate %89, %107 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %112 = neura.grant_predicate %87, %107 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %113 = neura.grant_predicate %77, %107 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %114 = neura.grant_predicate %91, %107 : !neura.data<memref<?x128x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %115 = neura.grant_predicate %85, %107 : !neura.data<memref<?x768x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x768x768xf32>, i1>
+// CTRL2DATA-NEXT:     %116 = neura.grant_predicate %81, %107 : !neura.data<memref<?x128x768xf32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %117 = neura.load_indexed %97[%98, %99, %100 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128x768xf32>, i1> : !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %118 = neura.load_indexed %101[%98, %100, %102 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x768x768xf32>, i1> : !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %119 = neura.load_indexed %103[%98, %99, %102 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128x768xf32>, i1> : !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %120 = "neura.fmul"(%117, %118) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %121 = "neura.fadd"(%119, %120) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %121 to %103[%98, %99, %102 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128x768xf32>, i1> : !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %122 = "neura.add"(%100, %104) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %122 -> %94 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %105 -> %92 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %97 -> %90 : !neura.data<memref<?x128x768xf32>, i1> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %98 -> %88 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %99 -> %86 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %101 -> %84 : !neura.data<memref<?x768x768xf32>, i1> !neura.data<memref<?x768x768xf32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %102 -> %82 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %103 -> %80 : !neura.data<memref<?x128x768xf32>, i1> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %104 -> %78 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %106 -> %76 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %123 = "neura.add"(%108, %109) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %123 -> %55 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %110 -> %53 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %111 -> %51 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %112 -> %49 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %109 -> %47 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %113 -> %45 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %114 -> %43 : !neura.data<memref<?x128x768xf32>, i1> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %115 -> %41 : !neura.data<memref<?x768x768xf32>, i1> !neura.data<memref<?x768x768xf32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %116 -> %39 : !neura.data<memref<?x128x768xf32>, i1> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     %124 = "neura.add"(%68, %69) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %124 -> %28 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %70 -> %26 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %71 -> %24 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %72 -> %22 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %69 -> %20 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %73 -> %18 : !neura.data<memref<?x128x768xf32>, i1> !neura.data<memref<?x128x768xf32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %74 -> %16 : !neura.data<memref<?x768x768xf32>, i1> !neura.data<memref<?x768x768xf32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %75 -> %14 : !neura.data<memref<?x128x768xf32>, i1> !neura.data<memref<?x128x768xf32>, i1>
 // CTRL2DATA-NEXT:     "neura.return"() : () -> ()
 // CTRL2DATA-NEXT:   }

--- a/test/controflow_fuse/complex_nested/complex_nested.mlir
+++ b/test/controflow_fuse/complex_nested/complex_nested.mlir
@@ -175,7 +175,7 @@ module attributes {} {
 // CHECK-NEXT:     "neura.return"() : () -> ()
 // CHECK-NEXT:   }
 
-// CTRL2DATA: func.func @_Z14complex_nestedPA32_A32_iPS_(%arg0: memref<?x32x32xi32>, %arg1: memref<?x32xi32>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
+// CTRL2DATA:        func.func @_Z14complex_nestedPA32_A32_iPS_(%arg0: memref<?x32x32xi32>, %arg1: memref<?x32xi32>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
 // CTRL2DATA-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<memref<?x32x32xi32>, i1>
 // CTRL2DATA-NEXT:     %1 = "neura.grant_once"(%0) : (!neura.data<memref<?x32x32xi32>, i1>) -> !neura.data<memref<?x32x32xi32>, i1>
 // CTRL2DATA-NEXT:     %2 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<memref<?x32xi32>, i1>
@@ -194,154 +194,478 @@ module attributes {} {
 // CTRL2DATA-NEXT:     %15 = "neura.grant_once"(%14) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
 // CTRL2DATA-NEXT:     %16 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %17 = "neura.grant_once"(%16) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %18 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %19 = "neura.phi"(%18, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %20 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %21 = "neura.phi"(%20, %17) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %22 = "neura.icmp"(%21, %19) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %23 = "neura.not"(%22) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %24 = neura.grant_predicate %17, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %25 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %26 = "neura.phi"(%25, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %27 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %28 = "neura.phi"(%27, %24) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %29 = "neura.icmp"(%28, %26) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %30 = neura.grant_predicate %15, %29 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %31 = neura.grant_predicate %3, %29 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
-// CTRL2DATA-NEXT:     %32 = neura.grant_predicate %21, %29 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %33 = neura.grant_predicate %28, %29 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %34 = neura.grant_predicate %17, %29 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %35 = "neura.not"(%29) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %36 = neura.grant_predicate %17, %35 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %37 = neura.grant_predicate %15, %35 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %30 to %31[%32, %33 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %38 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %39 = "neura.phi"(%38, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %40 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %41 = "neura.phi"(%40, %34) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %42 = "neura.icmp"(%41, %39) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %43 = neura.grant_predicate %1, %42 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
-// CTRL2DATA-NEXT:     %44 = neura.grant_predicate %21, %42 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %45 = neura.grant_predicate %28, %42 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %46 = neura.grant_predicate %41, %42 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %47 = neura.grant_predicate %3, %42 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
-// CTRL2DATA-NEXT:     %48 = neura.grant_predicate %5, %42 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %49 = neura.grant_predicate %7, %42 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %50 = "neura.not"(%42) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %51 = neura.grant_predicate %28, %50 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %52 = neura.grant_predicate %5, %50 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %53 = neura.grant_predicate %7, %50 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %54 = neura.load_indexed %43[%44, %45, %46 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %55 = neura.load_indexed %47[%44, %45 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %56 = "neura.add"(%55, %54) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %56 to %47[%44, %45 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %57 = "neura.add"(%46, %48) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %57 -> %40 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %49 -> %38 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %58 = "neura.add"(%51, %52) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %58 -> %27 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %53 -> %25 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %18 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %19 = "neura.phi"(%18, %9) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %20 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %21 = "neura.phi"(%20, %11) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %22 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %23 = "neura.phi"(%22, %13) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %24 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %25 = "neura.phi"(%24, %5) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %26 = neura.reserve : !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %27 = "neura.phi"(%26, %1) : (!neura.data<memref<?x32x32xi32>, i1>, !neura.data<memref<?x32x32xi32>, i1>) -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %28 = neura.reserve : !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %29 = "neura.phi"(%28, %3) : (!neura.data<memref<?x32xi32>, i1>, !neura.data<memref<?x32xi32>, i1>) -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %30 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %31 = "neura.phi"(%30, %15) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %32 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %33 = "neura.phi"(%32, %17) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %34 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %35 = "neura.phi"(%34, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %36 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %37 = "neura.phi"(%36, %17) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %38 = "neura.icmp"(%37, %35) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %39 = neura.grant_predicate %33, %38 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %40 = neura.grant_predicate %35, %38 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %41 = neura.grant_predicate %31, %38 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %42 = neura.grant_predicate %29, %38 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %43 = neura.grant_predicate %37, %38 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %44 = neura.grant_predicate %27, %38 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %45 = neura.grant_predicate %25, %38 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %46 = neura.grant_predicate %23, %38 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %47 = neura.grant_predicate %21, %38 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %48 = neura.grant_predicate %19, %38 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %49 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %50 = "neura.phi"(%49, %48) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %51 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %52 = "neura.phi"(%51, %47) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %53 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %54 = "neura.phi"(%53, %46) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %55 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %56 = "neura.phi"(%55, %45) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %57 = neura.reserve : !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %58 = "neura.phi"(%57, %44) : (!neura.data<memref<?x32x32xi32>, i1>, !neura.data<memref<?x32x32xi32>, i1>) -> !neura.data<memref<?x32x32xi32>, i1>
 // CTRL2DATA-NEXT:     %59 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %60 = "neura.phi"(%59, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %61 = neura.reserve : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %62 = "neura.phi"(%61, %37) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %63 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %64 = "neura.phi"(%63, %36) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %65 = "neura.icmp"(%64, %60) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %66 = neura.grant_predicate %3, %65 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
-// CTRL2DATA-NEXT:     %67 = neura.grant_predicate %21, %65 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %68 = neura.grant_predicate %64, %65 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %69 = neura.grant_predicate %62, %65 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %70 = neura.grant_predicate %5, %65 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %71 = neura.grant_predicate %7, %65 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %72 = "neura.not"(%65) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %73 = neura.grant_predicate %62, %72 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %74 = neura.grant_predicate %13, %72 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %75 = neura.grant_predicate %17, %72 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %76 = neura.load_indexed %66[%67, %68 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %77 = "neura.add"(%69, %76) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %78 = "neura.add"(%68, %70) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %78 -> %63 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %77 -> %61 : !neura.data<i32, i1> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %71 -> %59 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %79 = "neura.div"(%73, %74) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %80 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %81 = "neura.phi"(%80, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %82 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %83 = "neura.phi"(%82, %75) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %84 = "neura.icmp"(%83, %81) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %85 = neura.grant_predicate %17, %84 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %86 = neura.grant_predicate %11, %84 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %87 = "neura.not"(%84) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %88 = neura.grant_predicate %17, %87 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %89 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %90 = "neura.phi"(%89, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %91 = neura.reserve : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %92 = "neura.phi"(%91, %86) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %93 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %94 = "neura.phi"(%93, %85) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %95 = "neura.icmp"(%94, %90) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %96 = neura.grant_predicate %1, %95 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
-// CTRL2DATA-NEXT:     %97 = neura.grant_predicate %94, %95 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %98 = neura.grant_predicate %83, %95 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %99 = neura.grant_predicate %21, %95 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %100 = neura.grant_predicate %92, %95 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %101 = neura.grant_predicate %5, %95 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %102 = neura.grant_predicate %7, %95 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %103 = "neura.not"(%95) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %104 = neura.grant_predicate %3, %103 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
-// CTRL2DATA-NEXT:     %105 = neura.grant_predicate %21, %103 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %106 = neura.grant_predicate %83, %103 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %107 = neura.grant_predicate %92, %103 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %108 = neura.grant_predicate %9, %103 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %109 = neura.grant_predicate %5, %103 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %110 = neura.grant_predicate %7, %103 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %111 = neura.load_indexed %96[%97, %98, %99 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %112 = "neura.icmp"(%111, %100) <{cmpType = "sgt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %113 = "neura.sel"(%111, %100, %112) : (!neura.data<i32, i1>, !neura.data<i32, i1>, !neura.data<i1, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %114 = "neura.add"(%97, %101) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %114 -> %93 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %113 -> %91 : !neura.data<i32, i1> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %102 -> %89 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %115 = neura.load_indexed %104[%105, %106 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %116 = "neura.mul"(%115, %107) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %117 = "neura.div"(%116, %108) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %117 to %104[%105, %106 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %118 = "neura.add"(%106, %109) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %118 -> %82 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %110 -> %80 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %119 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %120 = "neura.phi"(%119, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %121 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %122 = "neura.phi"(%121, %88) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %123 = "neura.icmp"(%122, %120) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %124 = neura.grant_predicate %3, %123 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
-// CTRL2DATA-NEXT:     %125 = neura.grant_predicate %21, %123 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %126 = neura.grant_predicate %122, %123 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %127 = neura.grant_predicate %79, %123 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %128 = "neura.not"(%123) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %129 = neura.grant_predicate %21, %128 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %130 = neura.grant_predicate %5, %128 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %131 = neura.grant_predicate %7, %128 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %132 = neura.load_indexed %124[%125, %126 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %133 = "neura.icmp"(%132, %127) <{cmpType = "sgt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %134 = neura.grant_predicate %79, %133 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %135 = neura.grant_predicate %3, %133 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
-// CTRL2DATA-NEXT:     %136 = neura.grant_predicate %21, %133 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %137 = neura.grant_predicate %122, %133 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %138 = "neura.not"(%133) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %139 = neura.grant_predicate %122, %138 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %140 = neura.grant_predicate %5, %138 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %141 = neura.grant_predicate %7, %138 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %134 to %135[%136, %137 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %142 = "neura.phi"(%141, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %143 = "neura.phi"(%140, %5) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %144 = "neura.phi"(%139, %122) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %145 = "neura.add"(%144, %143) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %145 -> %121 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %142 -> %119 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %146 = "neura.add"(%129, %130) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %146 -> %20 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %131 -> %18 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %60 = "neura.phi"(%59, %39) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %61 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %62 = "neura.phi"(%61, %43) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %63 = neura.reserve : !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %64 = "neura.phi"(%63, %42) : (!neura.data<memref<?x32xi32>, i1>, !neura.data<memref<?x32xi32>, i1>) -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %65 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %66 = "neura.phi"(%65, %41) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %67 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %68 = "neura.phi"(%67, %40) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %69 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %70 = "neura.phi"(%69, %39) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %71 = "neura.icmp"(%70, %68) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %72 = neura.grant_predicate %66, %71 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %73 = neura.grant_predicate %64, %71 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %74 = neura.grant_predicate %62, %71 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %75 = neura.grant_predicate %70, %71 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %76 = neura.grant_predicate %60, %71 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %77 = neura.grant_predicate %68, %71 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %78 = neura.grant_predicate %58, %71 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %79 = neura.grant_predicate %56, %71 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %80 = neura.grant_predicate %54, %71 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %81 = neura.grant_predicate %52, %71 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %82 = neura.grant_predicate %50, %71 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %83 = "neura.not"(%71) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %84 = neura.grant_predicate %60, %83 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %85 = neura.grant_predicate %66, %83 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %86 = neura.grant_predicate %68, %83 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %87 = neura.grant_predicate %64, %83 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %88 = neura.grant_predicate %62, %83 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %89 = neura.grant_predicate %56, %83 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %90 = neura.grant_predicate %54, %83 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %91 = neura.grant_predicate %52, %83 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %92 = neura.grant_predicate %58, %83 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %93 = neura.grant_predicate %50, %83 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %72 to %73[%74, %75 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %94 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %95 = "neura.phi"(%94, %82) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %96 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %97 = "neura.phi"(%96, %81) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %98 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %99 = "neura.phi"(%98, %80) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %100 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %101 = "neura.phi"(%100, %76) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %102 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %103 = "neura.phi"(%102, %72) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %104 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %105 = "neura.phi"(%104, %79) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %106 = neura.reserve : !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %107 = "neura.phi"(%106, %73) : (!neura.data<memref<?x32xi32>, i1>, !neura.data<memref<?x32xi32>, i1>) -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %108 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %109 = "neura.phi"(%108, %75) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %110 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %111 = "neura.phi"(%110, %74) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %112 = neura.reserve : !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %113 = "neura.phi"(%112, %78) : (!neura.data<memref<?x32x32xi32>, i1>, !neura.data<memref<?x32x32xi32>, i1>) -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %114 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %115 = "neura.phi"(%114, %77) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %116 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %117 = "neura.phi"(%116, %76) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %118 = "neura.icmp"(%117, %115) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %119 = neura.grant_predicate %113, %118 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %120 = neura.grant_predicate %111, %118 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %121 = neura.grant_predicate %109, %118 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %122 = neura.grant_predicate %117, %118 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %123 = neura.grant_predicate %107, %118 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %124 = neura.grant_predicate %105, %118 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %125 = neura.grant_predicate %115, %118 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %126 = neura.grant_predicate %103, %118 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %127 = neura.grant_predicate %101, %118 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %128 = neura.grant_predicate %99, %118 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %129 = neura.grant_predicate %97, %118 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %130 = neura.grant_predicate %95, %118 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %131 = "neura.not"(%118) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %132 = neura.grant_predicate %109, %131 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %133 = neura.grant_predicate %105, %131 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %134 = neura.grant_predicate %115, %131 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %135 = neura.grant_predicate %103, %131 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %136 = neura.grant_predicate %107, %131 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %137 = neura.grant_predicate %111, %131 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %138 = neura.grant_predicate %101, %131 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %139 = neura.grant_predicate %113, %131 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %140 = neura.grant_predicate %99, %131 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %141 = neura.grant_predicate %97, %131 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %142 = neura.grant_predicate %95, %131 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %143 = neura.load_indexed %119[%120, %121, %122 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %144 = neura.load_indexed %123[%120, %121 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %145 = "neura.add"(%144, %143) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %145 to %123[%120, %121 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %146 = "neura.add"(%122, %124) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %146 -> %116 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %125 -> %114 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %119 -> %112 : !neura.data<memref<?x32x32xi32>, i1> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %120 -> %110 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %121 -> %108 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %123 -> %106 : !neura.data<memref<?x32xi32>, i1> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %124 -> %104 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %126 -> %102 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %127 -> %100 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %128 -> %98 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %129 -> %96 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %130 -> %94 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %147 = "neura.add"(%132, %133) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %147 -> %69 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %134 -> %67 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %135 -> %65 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %136 -> %63 : !neura.data<memref<?x32xi32>, i1> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %137 -> %61 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %138 -> %59 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %139 -> %57 : !neura.data<memref<?x32x32xi32>, i1> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %133 -> %55 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %140 -> %53 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %141 -> %51 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %142 -> %49 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %148 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %149 = "neura.phi"(%148, %85) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %150 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %151 = "neura.phi"(%150, %93) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %152 = neura.reserve : !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %153 = "neura.phi"(%152, %92) : (!neura.data<memref<?x32x32xi32>, i1>, !neura.data<memref<?x32x32xi32>, i1>) -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %154 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %155 = "neura.phi"(%154, %91) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %156 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %157 = "neura.phi"(%156, %84) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %158 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %159 = "neura.phi"(%158, %90) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %160 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %161 = "neura.phi"(%160, %89) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %162 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %163 = "neura.phi"(%162, %88) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %164 = neura.reserve : !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %165 = "neura.phi"(%164, %87) : (!neura.data<memref<?x32xi32>, i1>, !neura.data<memref<?x32xi32>, i1>) -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %166 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %167 = "neura.phi"(%166, %86) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %168 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %169 = "neura.phi"(%168, %85) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %170 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %171 = "neura.phi"(%170, %84) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %172 = "neura.icmp"(%171, %167) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %173 = neura.grant_predicate %165, %172 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %174 = neura.grant_predicate %163, %172 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %175 = neura.grant_predicate %171, %172 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %176 = neura.grant_predicate %169, %172 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %177 = neura.grant_predicate %161, %172 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %178 = neura.grant_predicate %167, %172 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %179 = neura.grant_predicate %159, %172 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %180 = neura.grant_predicate %157, %172 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %181 = neura.grant_predicate %155, %172 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %182 = neura.grant_predicate %153, %172 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %183 = neura.grant_predicate %151, %172 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %184 = neura.grant_predicate %149, %172 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %185 = "neura.not"(%172) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %186 = neura.grant_predicate %169, %185 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %187 = neura.grant_predicate %159, %185 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %188 = neura.grant_predicate %157, %185 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %189 = neura.grant_predicate %167, %185 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %190 = neura.grant_predicate %155, %185 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %191 = neura.grant_predicate %153, %185 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %192 = neura.grant_predicate %163, %185 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %193 = neura.grant_predicate %161, %185 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %194 = neura.grant_predicate %165, %185 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %195 = neura.grant_predicate %151, %185 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %196 = neura.grant_predicate %149, %185 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %197 = neura.load_indexed %173[%174, %175 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %198 = "neura.add"(%176, %197) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %199 = "neura.add"(%175, %177) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %199 -> %170 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %198 -> %168 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %178 -> %166 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %173 -> %164 : !neura.data<memref<?x32xi32>, i1> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %174 -> %162 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %177 -> %160 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %179 -> %158 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %180 -> %156 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %181 -> %154 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %182 -> %152 : !neura.data<memref<?x32x32xi32>, i1> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %183 -> %150 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %184 -> %148 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %200 = "neura.div"(%186, %187) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %201 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %202 = "neura.phi"(%201, %187) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %203 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %204 = "neura.phi"(%203, %196) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %205 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %206 = "neura.phi"(%205, %200) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %207 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %208 = "neura.phi"(%207, %195) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %209 = neura.reserve : !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %210 = "neura.phi"(%209, %194) : (!neura.data<memref<?x32xi32>, i1>, !neura.data<memref<?x32xi32>, i1>) -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %211 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %212 = "neura.phi"(%211, %193) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %213 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %214 = "neura.phi"(%213, %192) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %215 = neura.reserve : !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %216 = "neura.phi"(%215, %191) : (!neura.data<memref<?x32x32xi32>, i1>, !neura.data<memref<?x32x32xi32>, i1>) -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %217 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %218 = "neura.phi"(%217, %190) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %219 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %220 = "neura.phi"(%219, %188) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %221 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %222 = "neura.phi"(%221, %189) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %223 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %224 = "neura.phi"(%223, %188) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %225 = "neura.icmp"(%224, %222) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %226 = neura.grant_predicate %220, %225 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %227 = neura.grant_predicate %218, %225 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %228 = neura.grant_predicate %222, %225 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %229 = neura.grant_predicate %216, %225 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %230 = neura.grant_predicate %224, %225 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %231 = neura.grant_predicate %214, %225 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %232 = neura.grant_predicate %212, %225 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %233 = neura.grant_predicate %210, %225 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %234 = neura.grant_predicate %208, %225 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %235 = neura.grant_predicate %206, %225 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %236 = neura.grant_predicate %204, %225 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %237 = neura.grant_predicate %202, %225 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %238 = "neura.not"(%225) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %239 = neura.grant_predicate %220, %238 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %240 = neura.grant_predicate %222, %238 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %241 = neura.grant_predicate %210, %238 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %242 = neura.grant_predicate %214, %238 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %243 = neura.grant_predicate %206, %238 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %244 = neura.grant_predicate %212, %238 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %245 = neura.grant_predicate %204, %238 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %246 = neura.grant_predicate %216, %238 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %247 = neura.grant_predicate %202, %238 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %248 = neura.grant_predicate %218, %238 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %249 = neura.grant_predicate %208, %238 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %250 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %251 = "neura.phi"(%250, %237) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %252 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %253 = "neura.phi"(%252, %236) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %254 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %255 = "neura.phi"(%254, %235) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %256 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %257 = "neura.phi"(%256, %227) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %258 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %259 = "neura.phi"(%258, %226) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %260 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %261 = "neura.phi"(%260, %234) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %262 = neura.reserve : !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %263 = "neura.phi"(%262, %233) : (!neura.data<memref<?x32xi32>, i1>, !neura.data<memref<?x32xi32>, i1>) -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %264 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %265 = "neura.phi"(%264, %232) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %266 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %267 = "neura.phi"(%266, %231) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %268 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %269 = "neura.phi"(%268, %230) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %270 = neura.reserve : !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %271 = "neura.phi"(%270, %229) : (!neura.data<memref<?x32x32xi32>, i1>, !neura.data<memref<?x32x32xi32>, i1>) -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %272 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %273 = "neura.phi"(%272, %228) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %274 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %275 = "neura.phi"(%274, %227) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %276 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %277 = "neura.phi"(%276, %226) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %278 = "neura.icmp"(%277, %273) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %279 = neura.grant_predicate %271, %278 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %280 = neura.grant_predicate %277, %278 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %281 = neura.grant_predicate %269, %278 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %282 = neura.grant_predicate %267, %278 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %283 = neura.grant_predicate %275, %278 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %284 = neura.grant_predicate %265, %278 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %285 = neura.grant_predicate %273, %278 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %286 = neura.grant_predicate %263, %278 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %287 = neura.grant_predicate %261, %278 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %288 = neura.grant_predicate %259, %278 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %289 = neura.grant_predicate %257, %278 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %290 = neura.grant_predicate %255, %278 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %291 = neura.grant_predicate %253, %278 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %292 = neura.grant_predicate %251, %278 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %293 = "neura.not"(%278) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %294 = neura.grant_predicate %263, %293 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %295 = neura.grant_predicate %267, %293 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %296 = neura.grant_predicate %269, %293 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %297 = neura.grant_predicate %275, %293 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %298 = neura.grant_predicate %261, %293 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %299 = neura.grant_predicate %265, %293 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %300 = neura.grant_predicate %273, %293 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %301 = neura.grant_predicate %259, %293 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %302 = neura.grant_predicate %257, %293 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %303 = neura.grant_predicate %271, %293 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %304 = neura.grant_predicate %255, %293 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %305 = neura.grant_predicate %253, %293 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %306 = neura.grant_predicate %251, %293 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %307 = neura.load_indexed %279[%280, %281, %282 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %308 = "neura.icmp"(%307, %283) <{cmpType = "sgt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %309 = "neura.sel"(%307, %283, %308) : (!neura.data<i32, i1>, !neura.data<i32, i1>, !neura.data<i1, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %310 = "neura.add"(%280, %284) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %310 -> %276 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %309 -> %274 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %285 -> %272 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %279 -> %270 : !neura.data<memref<?x32x32xi32>, i1> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %281 -> %268 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %282 -> %266 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %284 -> %264 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %286 -> %262 : !neura.data<memref<?x32xi32>, i1> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %287 -> %260 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %288 -> %258 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %289 -> %256 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %290 -> %254 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %291 -> %252 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %292 -> %250 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %311 = neura.load_indexed %294[%295, %296 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %312 = "neura.mul"(%311, %297) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %313 = "neura.div"(%312, %298) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %313 to %294[%295, %296 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %314 = "neura.add"(%296, %299) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>  
+// CTRL2DATA-NEXT:     neura.ctrl_mov %314 -> %223 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %300 -> %221 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %301 -> %219 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %302 -> %217 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %303 -> %215 : !neura.data<memref<?x32x32xi32>, i1> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %295 -> %213 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %299 -> %211 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %294 -> %209 : !neura.data<memref<?x32xi32>, i1> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %298 -> %207 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %304 -> %205 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %305 -> %203 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %306 -> %201 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %315 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %316 = "neura.phi"(%315, %249) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %317 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %318 = "neura.phi"(%317, %248) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %319 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %320 = "neura.phi"(%319, %247) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %321 = neura.reserve : !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %322 = "neura.phi"(%321, %246) : (!neura.data<memref<?x32x32xi32>, i1>, !neura.data<memref<?x32x32xi32>, i1>) -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %323 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %324 = "neura.phi"(%323, %245) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %325 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %326 = "neura.phi"(%325, %239) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %327 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %328 = "neura.phi"(%327, %244) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %329 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %330 = "neura.phi"(%329, %243) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %331 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %332 = "neura.phi"(%331, %242) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %333 = neura.reserve : !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %334 = "neura.phi"(%333, %241) : (!neura.data<memref<?x32xi32>, i1>, !neura.data<memref<?x32xi32>, i1>) -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %335 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %336 = "neura.phi"(%335, %240) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %337 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %338 = "neura.phi"(%337, %239) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %339 = "neura.icmp"(%338, %336) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %340 = neura.grant_predicate %334, %339 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %341 = neura.grant_predicate %332, %339 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %342 = neura.grant_predicate %338, %339 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %343 = neura.grant_predicate %330, %339 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %344 = neura.grant_predicate %328, %339 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %345 = neura.grant_predicate %336, %339 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %346 = neura.grant_predicate %326, %339 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %347 = neura.grant_predicate %324, %339 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %348 = neura.grant_predicate %322, %339 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %349 = neura.grant_predicate %320, %339 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %350 = neura.grant_predicate %318, %339 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %351 = neura.grant_predicate %316, %339 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %352 = "neura.not"(%339) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %353 = neura.grant_predicate %332, %352 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %354 = neura.grant_predicate %328, %352 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %355 = neura.grant_predicate %336, %352 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %356 = neura.grant_predicate %326, %352 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %357 = neura.grant_predicate %324, %352 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %358 = neura.grant_predicate %334, %352 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %359 = neura.grant_predicate %322, %352 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %360 = neura.grant_predicate %320, %352 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %361 = neura.grant_predicate %318, %352 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %362 = neura.grant_predicate %316, %352 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %363 = neura.load_indexed %340[%341, %342 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %364 = "neura.icmp"(%363, %343) <{cmpType = "sgt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %365 = neura.grant_predicate %343, %364 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %366 = neura.grant_predicate %340, %364 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %367 = neura.grant_predicate %341, %364 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %368 = neura.grant_predicate %342, %364 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %369 = neura.grant_predicate %344, %364 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %370 = neura.grant_predicate %345, %364 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %371 = neura.grant_predicate %346, %364 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %372 = neura.grant_predicate %347, %364 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %373 = neura.grant_predicate %348, %364 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %374 = neura.grant_predicate %349, %364 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %375 = neura.grant_predicate %350, %364 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %376 = neura.grant_predicate %351, %364 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %377 = "neura.not"(%364) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %378 = neura.grant_predicate %342, %377 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %379 = neura.grant_predicate %344, %377 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %380 = neura.grant_predicate %345, %377 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %381 = neura.grant_predicate %340, %377 : !neura.data<memref<?x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %382 = neura.grant_predicate %341, %377 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %383 = neura.grant_predicate %343, %377 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %384 = neura.grant_predicate %346, %377 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %385 = neura.grant_predicate %347, %377 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %386 = neura.grant_predicate %348, %377 : !neura.data<memref<?x32x32xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %387 = neura.grant_predicate %349, %377 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %388 = neura.grant_predicate %350, %377 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %389 = neura.grant_predicate %351, %377 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %365 to %366[%367, %368 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x32xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %390 = "neura.phi"(%389, %376) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %391 = "neura.phi"(%388, %375) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %392 = "neura.phi"(%387, %374) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %393 = "neura.phi"(%386, %373) : (!neura.data<memref<?x32x32xi32>, i1>, !neura.data<memref<?x32x32xi32>, i1>) -> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     %394 = "neura.phi"(%385, %372) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %395 = "neura.phi"(%384, %371) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %396 = "neura.phi"(%383, %365) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %397 = "neura.phi"(%382, %367) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %398 = "neura.phi"(%381, %366) : (!neura.data<memref<?x32xi32>, i1>, !neura.data<memref<?x32xi32>, i1>) -> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     %399 = "neura.phi"(%380, %370) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %400 = "neura.phi"(%379, %369) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %401 = "neura.phi"(%378, %368) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %402 = "neura.add"(%401, %400) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %402 -> %337 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %399 -> %335 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %398 -> %333 : !neura.data<memref<?x32xi32>, i1> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %397 -> %331 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %396 -> %329 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %400 -> %327 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %395 -> %325 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %394 -> %323 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %393 -> %321 : !neura.data<memref<?x32x32xi32>, i1> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %392 -> %319 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %391 -> %317 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %390 -> %315 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %403 = "neura.add"(%353, %354) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %403 -> %36 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %355 -> %34 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %356 -> %32 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %357 -> %30 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %358 -> %28 : !neura.data<memref<?x32xi32>, i1> !neura.data<memref<?x32xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %359 -> %26 : !neura.data<memref<?x32x32xi32>, i1> !neura.data<memref<?x32x32xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %354 -> %24 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %360 -> %22 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %361 -> %20 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %362 -> %18 : !neura.data<i32, i1> !neura.data<i32, i1>
 // CTRL2DATA-NEXT:     "neura.return"() : () -> ()
 // CTRL2DATA-NEXT:   }

--- a/test/controflow_fuse/non_perfect_nested/non_perfect_nested.mlir
+++ b/test/controflow_fuse/non_perfect_nested/non_perfect_nested.mlir
@@ -137,7 +137,7 @@ module attributes {} {
 // CHECK-NEXT:     "neura.return"() : () -> ()
 // CHECK-NEXT:   }
 
-// CTRL2DATA:   func.func @_Z29non_perfect_extra_computationPA128_iS0_(%arg0: memref<?x128xi32>, %arg1: memref<?x128xi32>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
+// CTRL2DATA:        func.func @_Z29non_perfect_extra_computationPA128_iS0_(%arg0: memref<?x128xi32>, %arg1: memref<?x128xi32>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
 // CTRL2DATA-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<memref<?x128xi32>, i1>
 // CTRL2DATA-NEXT:     %1 = "neura.grant_once"(%0) : (!neura.data<memref<?x128xi32>, i1>) -> !neura.data<memref<?x128xi32>, i1>
 // CTRL2DATA-NEXT:     %2 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<memref<?x128xi32>, i1>
@@ -169,84 +169,263 @@ module attributes {} {
 // CTRL2DATA-NEXT:     %28 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %29 = "neura.grant_once"(%28) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %30 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %31 = "neura.phi"(%30, %13) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %31 = "neura.phi"(%30, %5) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %32 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %33 = "neura.phi"(%32, %29) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %34 = "neura.icmp"(%33, %31) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %35 = "neura.not"(%34) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %36 = neura.grant_predicate %33, %34 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %37 = neura.grant_predicate %19, %34 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %38 = neura.grant_predicate %27, %34 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %39 = neura.grant_predicate %17, %34 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %40 = neura.grant_predicate %29, %34 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %41 = neura.grant_predicate %21, %34 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %42 = neura.grant_predicate %23, %34 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %43 = "neura.cast"(%36) <{cast_type = "i64_to_i32"}> : (!neura.data<i64, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %44 = "neura.div"(%43, %37) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %45 = "neura.mul"(%37, %44) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %46 = "neura.sub"(%43, %45) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %47 = "neura.icmp"(%46, %38) <{cmpType = "eq"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %48 = "neura.sel"(%37, %39, %47) : (!neura.data<i32, i1>, !neura.data<i32, i1>, !neura.data<i1, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %49 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %50 = "neura.phi"(%49, %13) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %51 = neura.reserve : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %52 = "neura.phi"(%51, %38) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %53 = neura.reserve : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %54 = "neura.phi"(%53, %42) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %55 = neura.reserve : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %56 = "neura.phi"(%55, %41) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %57 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %58 = "neura.phi"(%57, %40) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %59 = "neura.icmp"(%58, %50) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %60 = neura.grant_predicate %1, %59 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
-// CTRL2DATA-NEXT:     %61 = neura.grant_predicate %33, %59 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %62 = neura.grant_predicate %58, %59 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %63 = neura.grant_predicate %48, %59 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %64 = neura.grant_predicate %3, %59 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
-// CTRL2DATA-NEXT:     %65 = neura.grant_predicate %52, %59 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %66 = neura.grant_predicate %54, %59 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %67 = neura.grant_predicate %56, %59 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %68 = neura.grant_predicate %11, %59 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %69 = neura.grant_predicate %13, %59 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %70 = "neura.not"(%59) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %71 = neura.grant_predicate %52, %70 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %72 = neura.grant_predicate %25, %70 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %73 = neura.grant_predicate %54, %70 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %74 = neura.grant_predicate %56, %70 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %75 = neura.grant_predicate %27, %70 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %76 = neura.load_indexed %60[%61, %62 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %77 = "neura.mul"(%76, %63) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %77 to %64[%61, %62 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %78 = neura.load_indexed %60[%61, %62 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %79 = "neura.add"(%65, %78) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %80 = "neura.icmp"(%78, %66) <{cmpType = "sgt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %81 = "neura.sel"(%78, %66, %80) : (!neura.data<i32, i1>, !neura.data<i32, i1>, !neura.data<i1, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %82 = "neura.icmp"(%78, %67) <{cmpType = "slt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %83 = "neura.sel"(%78, %67, %82) : (!neura.data<i32, i1>, !neura.data<i32, i1>, !neura.data<i1, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %84 = "neura.add"(%62, %68) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %84 -> %57 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %83 -> %55 : !neura.data<i32, i1> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %81 -> %53 : !neura.data<i32, i1> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %79 -> %51 : !neura.data<i32, i1> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %69 -> %49 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %85 = "neura.div"(%71, %72) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %86 = "neura.sub"(%73, %74) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %87 = "neura.icmp"(%86, %75) <{cmpType = "sgt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %88 = neura.grant_predicate %85, %87 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %89 = neura.grant_predicate %15, %87 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %90 = neura.grant_predicate %86, %87 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %91 = "neura.not"(%87) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %92 = neura.grant_predicate %85, %91 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %93 = "neura.mul"(%88, %89) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %94 = "neura.div"(%93, %90) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %95 = "neura.phi"(%94, %92) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %85 to %3[%33, %29 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %54 to %3[%33, %11 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %56 to %3[%33, %9 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %95 to %3[%33, %7 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %86 to %3[%33, %5 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %96 = "neura.add"(%33, %11) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %96 -> %32 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %13 -> %30 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %33 = "neura.phi"(%32, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %34 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %35 = "neura.phi"(%34, %9) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %36 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %37 = "neura.phi"(%36, %15) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %38 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %39 = "neura.phi"(%38, %25) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %40 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %41 = "neura.phi"(%40, %11) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %42 = neura.reserve : !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %43 = "neura.phi"(%42, %3) : (!neura.data<memref<?x128xi32>, i1>, !neura.data<memref<?x128xi32>, i1>) -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %44 = neura.reserve : !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %45 = "neura.phi"(%44, %1) : (!neura.data<memref<?x128xi32>, i1>, !neura.data<memref<?x128xi32>, i1>) -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %46 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %47 = "neura.phi"(%46, %23) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %48 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %49 = "neura.phi"(%48, %21) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %50 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %51 = "neura.phi"(%50, %29) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %52 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %53 = "neura.phi"(%52, %17) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %54 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %55 = "neura.phi"(%54, %27) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %56 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %57 = "neura.phi"(%56, %19) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %58 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %59 = "neura.phi"(%58, %13) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %60 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %61 = "neura.phi"(%60, %29) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %62 = "neura.icmp"(%61, %59) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %63 = neura.grant_predicate %61, %62 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %64 = neura.grant_predicate %57, %62 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %65 = neura.grant_predicate %55, %62 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %66 = neura.grant_predicate %53, %62 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %67 = neura.grant_predicate %51, %62 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %68 = neura.grant_predicate %49, %62 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %69 = neura.grant_predicate %47, %62 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %70 = neura.grant_predicate %59, %62 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %71 = neura.grant_predicate %45, %62 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %72 = neura.grant_predicate %43, %62 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %73 = neura.grant_predicate %41, %62 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %74 = neura.grant_predicate %39, %62 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %75 = neura.grant_predicate %37, %62 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %76 = neura.grant_predicate %35, %62 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %77 = neura.grant_predicate %33, %62 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %78 = neura.grant_predicate %31, %62 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %79 = "neura.cast"(%63) <{cast_type = "i64_to_i32"}> : (!neura.data<i64, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %80 = "neura.div"(%79, %64) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %81 = "neura.mul"(%64, %80) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %82 = "neura.sub"(%79, %81) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %83 = "neura.icmp"(%82, %65) <{cmpType = "eq"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %84 = "neura.sel"(%64, %66, %83) : (!neura.data<i32, i1>, !neura.data<i32, i1>, !neura.data<i1, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %85 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %86 = "neura.phi"(%85, %69) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %87 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %88 = "neura.phi"(%87, %68) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %89 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %90 = "neura.phi"(%89, %66) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %91 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %92 = "neura.phi"(%91, %64) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %93 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %94 = "neura.phi"(%93, %78) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %95 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %96 = "neura.phi"(%95, %77) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %97 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %98 = "neura.phi"(%97, %76) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %99 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %100 = "neura.phi"(%99, %67) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %101 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %102 = "neura.phi"(%101, %75) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %103 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %104 = "neura.phi"(%103, %65) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %105 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %106 = "neura.phi"(%105, %74) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %107 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %108 = "neura.phi"(%107, %73) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %109 = neura.reserve : !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %110 = "neura.phi"(%109, %72) : (!neura.data<memref<?x128xi32>, i1>, !neura.data<memref<?x128xi32>, i1>) -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %111 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %112 = "neura.phi"(%111, %84) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %113 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %114 = "neura.phi"(%113, %63) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %115 = neura.reserve : !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %116 = "neura.phi"(%115, %71) : (!neura.data<memref<?x128xi32>, i1>, !neura.data<memref<?x128xi32>, i1>) -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %117 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %118 = "neura.phi"(%117, %70) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %119 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %120 = "neura.phi"(%119, %65) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %121 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %122 = "neura.phi"(%121, %69) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %123 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %124 = "neura.phi"(%123, %68) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %125 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %126 = "neura.phi"(%125, %67) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %127 = "neura.icmp"(%126, %118) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %128 = neura.grant_predicate %116, %127 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %129 = neura.grant_predicate %114, %127 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %130 = neura.grant_predicate %126, %127 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %131 = neura.grant_predicate %112, %127 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %132 = neura.grant_predicate %110, %127 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %133 = neura.grant_predicate %120, %127 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %134 = neura.grant_predicate %122, %127 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %135 = neura.grant_predicate %124, %127 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %136 = neura.grant_predicate %108, %127 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %137 = neura.grant_predicate %118, %127 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %138 = neura.grant_predicate %106, %127 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %139 = neura.grant_predicate %104, %127 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %140 = neura.grant_predicate %102, %127 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %141 = neura.grant_predicate %100, %127 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %142 = neura.grant_predicate %98, %127 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %143 = neura.grant_predicate %96, %127 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %144 = neura.grant_predicate %94, %127 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %145 = neura.grant_predicate %92, %127 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %146 = neura.grant_predicate %90, %127 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %147 = neura.grant_predicate %88, %127 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %148 = neura.grant_predicate %86, %127 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %149 = "neura.not"(%127) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %150 = neura.grant_predicate %120, %149 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %151 = neura.grant_predicate %106, %149 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %152 = neura.grant_predicate %122, %149 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %153 = neura.grant_predicate %124, %149 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %154 = neura.grant_predicate %104, %149 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %155 = neura.grant_predicate %102, %149 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %156 = neura.grant_predicate %110, %149 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %157 = neura.grant_predicate %114, %149 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %158 = neura.grant_predicate %100, %149 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %159 = neura.grant_predicate %108, %149 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %160 = neura.grant_predicate %98, %149 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %161 = neura.grant_predicate %96, %149 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %162 = neura.grant_predicate %94, %149 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %163 = neura.grant_predicate %118, %149 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %164 = neura.grant_predicate %92, %149 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %165 = neura.grant_predicate %90, %149 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %166 = neura.grant_predicate %88, %149 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %167 = neura.grant_predicate %86, %149 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %168 = neura.grant_predicate %116, %149 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %169 = neura.load_indexed %128[%129, %130 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %170 = "neura.mul"(%169, %131) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %170 to %132[%129, %130 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %171 = neura.load_indexed %128[%129, %130 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %172 = "neura.add"(%133, %171) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %173 = "neura.icmp"(%171, %134) <{cmpType = "sgt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %174 = "neura.sel"(%171, %134, %173) : (!neura.data<i32, i1>, !neura.data<i32, i1>, !neura.data<i1, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %175 = "neura.icmp"(%171, %135) <{cmpType = "slt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %176 = "neura.sel"(%171, %135, %175) : (!neura.data<i32, i1>, !neura.data<i32, i1>, !neura.data<i1, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %177 = "neura.add"(%130, %136) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %177 -> %125 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %176 -> %123 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %174 -> %121 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %172 -> %119 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %137 -> %117 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %128 -> %115 : !neura.data<memref<?x128xi32>, i1> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %129 -> %113 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %131 -> %111 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %132 -> %109 : !neura.data<memref<?x128xi32>, i1> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %136 -> %107 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %138 -> %105 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %139 -> %103 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %140 -> %101 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %141 -> %99 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %142 -> %97 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %143 -> %95 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %144 -> %93 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %145 -> %91 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %146 -> %89 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %147 -> %87 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %148 -> %85 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %178 = "neura.div"(%150, %151) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %179 = "neura.sub"(%152, %153) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %180 = "neura.icmp"(%179, %154) <{cmpType = "sgt"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %181 = neura.grant_predicate %178, %180 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %182 = neura.grant_predicate %155, %180 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %183 = neura.grant_predicate %179, %180 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %184 = neura.grant_predicate %156, %180 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %185 = neura.grant_predicate %157, %180 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %186 = neura.grant_predicate %158, %180 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %187 = neura.grant_predicate %152, %180 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %188 = neura.grant_predicate %159, %180 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %189 = neura.grant_predicate %153, %180 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %190 = neura.grant_predicate %160, %180 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %191 = neura.grant_predicate %161, %180 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %192 = neura.grant_predicate %162, %180 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %193 = neura.grant_predicate %163, %180 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %194 = neura.grant_predicate %164, %180 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %195 = neura.grant_predicate %154, %180 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %196 = neura.grant_predicate %165, %180 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %197 = neura.grant_predicate %166, %180 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %198 = neura.grant_predicate %167, %180 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %199 = neura.grant_predicate %168, %180 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %200 = neura.grant_predicate %151, %180 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %201 = "neura.not"(%180) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %202 = neura.grant_predicate %178, %201 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %203 = neura.grant_predicate %156, %201 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %204 = neura.grant_predicate %157, %201 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %205 = neura.grant_predicate %158, %201 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %206 = neura.grant_predicate %152, %201 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %207 = neura.grant_predicate %159, %201 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %208 = neura.grant_predicate %153, %201 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %209 = neura.grant_predicate %160, %201 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %210 = neura.grant_predicate %161, %201 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %211 = neura.grant_predicate %179, %201 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %212 = neura.grant_predicate %162, %201 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %213 = neura.grant_predicate %163, %201 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %214 = neura.grant_predicate %164, %201 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %215 = neura.grant_predicate %154, %201 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %216 = neura.grant_predicate %165, %201 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %217 = neura.grant_predicate %166, %201 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %218 = neura.grant_predicate %167, %201 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %219 = neura.grant_predicate %168, %201 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %220 = neura.grant_predicate %151, %201 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %221 = neura.grant_predicate %155, %201 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %222 = "neura.mul"(%181, %182) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %223 = "neura.div"(%222, %183) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %224 = "neura.phi"(%182, %221) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %225 = "neura.phi"(%200, %220) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %226 = "neura.phi"(%199, %219) : (!neura.data<memref<?x128xi32>, i1>, !neura.data<memref<?x128xi32>, i1>) -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %227 = "neura.phi"(%198, %218) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %228 = "neura.phi"(%197, %217) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %229 = "neura.phi"(%196, %216) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %230 = "neura.phi"(%195, %215) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %231 = "neura.phi"(%194, %214) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %232 = "neura.phi"(%193, %213) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %233 = "neura.phi"(%192, %212) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %234 = "neura.phi"(%183, %211) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %235 = "neura.phi"(%191, %210) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %236 = "neura.phi"(%190, %209) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %237 = "neura.phi"(%189, %208) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %238 = "neura.phi"(%188, %207) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %239 = "neura.phi"(%187, %206) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %240 = "neura.phi"(%186, %205) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %241 = "neura.phi"(%185, %204) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %242 = "neura.phi"(%184, %203) : (!neura.data<memref<?x128xi32>, i1>, !neura.data<memref<?x128xi32>, i1>) -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %243 = "neura.phi"(%181, %202) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %244 = "neura.phi"(%223, %202) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %243 to %242[%241, %240 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %239 to %242[%241, %238 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %237 to %242[%241, %236 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %244 to %242[%241, %235 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %234 to %242[%241, %233 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %245 = "neura.add"(%241, %238) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %245 -> %60 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %232 -> %58 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %231 -> %56 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %230 -> %54 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %229 -> %52 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %240 -> %50 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %228 -> %48 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %227 -> %46 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %226 -> %44 : !neura.data<memref<?x128xi32>, i1> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %242 -> %42 : !neura.data<memref<?x128xi32>, i1> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %238 -> %40 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %225 -> %38 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %224 -> %36 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %236 -> %34 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %235 -> %32 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %233 -> %30 : !neura.data<i64, i1> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     "neura.return"() : () -> ()
 // CTRL2DATA-NEXT:   }

--- a/test/controflow_fuse/perfect_nested/perfect_nested.mlir
+++ b/test/controflow_fuse/perfect_nested/perfect_nested.mlir
@@ -96,7 +96,7 @@ module attributes {} {
 // CAST-NEXT:     "neura.return"() : () -> ()
 // CAST-NEXT:   }
 
-// CTRL2DATA:     func.func @_Z10bert_node1PA1_A1_A1_A1_A128_bPA1_A128_S1_(%arg0: memref<?x1x1x1x1x128xi8>, %arg1: memref<?x1x128x1x1x128xi8>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
+// CTRL2DATA:        func.func @_Z10bert_node1PA1_A1_A1_A1_A128_bPA1_A128_S1_(%arg0: memref<?x1x1x1x1x128xi8>, %arg1: memref<?x1x128x1x1x128xi8>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
 // CTRL2DATA-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
 // CTRL2DATA-NEXT:     %1 = "neura.grant_once"(%0) : (!neura.data<memref<?x1x1x1x1x128xi8>, i1>) -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
 // CTRL2DATA-NEXT:     %2 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
@@ -108,35 +108,69 @@ module attributes {} {
 // CTRL2DATA-NEXT:     %8 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %9 = "neura.grant_once"(%8) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %10 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %11 = "neura.phi"(%10, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %12 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %13 = "neura.phi"(%12, %9) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %14 = "neura.icmp"(%13, %11) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %15 = "neura.not"(%14) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %16 = neura.grant_predicate %9, %14 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %17 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %18 = "neura.phi"(%17, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %19 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %20 = "neura.phi"(%19, %16) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %21 = "neura.icmp"(%20, %18) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %22 = neura.grant_predicate %1, %21 : !neura.data<memref<?x1x1x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
-// CTRL2DATA-NEXT:     %23 = neura.grant_predicate %9, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %24 = neura.grant_predicate %20, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %25 = neura.grant_predicate %3, %21 : !neura.data<memref<?x1x128x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
-// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %13, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %27 = neura.grant_predicate %5, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %28 = neura.grant_predicate %7, %21 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %29 = "neura.not"(%21) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %30 = neura.grant_predicate %13, %29 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %31 = neura.grant_predicate %5, %29 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %32 = neura.grant_predicate %7, %29 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %33 = neura.load_indexed %22[%23, %23, %23, %23, %23, %24 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x1x1x1x1x128xi8>, i1> : !neura.data<i8, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %33 to %25[%23, %23, %26, %23, %23, %24 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x1x128x1x1x128xi8>, i1> : !neura.data<i8, i1>
-// CTRL2DATA-NEXT:     %34 = "neura.add"(%24, %27) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %34 -> %19 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %28 -> %17 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %35 = "neura.add"(%30, %31) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %35 -> %12 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %32 -> %10 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %11 = "neura.phi"(%10, %5) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %12 = neura.reserve : !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %13 = "neura.phi"(%12, %3) : (!neura.data<memref<?x1x128x1x1x128xi8>, i1>, !neura.data<memref<?x1x128x1x1x128xi8>, i1>) -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %14 = neura.reserve : !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %15 = "neura.phi"(%14, %1) : (!neura.data<memref<?x1x1x1x1x128xi8>, i1>, !neura.data<memref<?x1x1x1x1x128xi8>, i1>) -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %16 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %17 = "neura.phi"(%16, %9) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %18 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %19 = "neura.phi"(%18, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %20 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %21 = "neura.phi"(%20, %9) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %22 = "neura.icmp"(%21, %19) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %23 = neura.grant_predicate %17, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %24 = neura.grant_predicate %19, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %25 = neura.grant_predicate %15, %22 : !neura.data<memref<?x1x1x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %13, %22 : !neura.data<memref<?x1x128x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %27 = neura.grant_predicate %21, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %28 = neura.grant_predicate %11, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %29 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %30 = "neura.phi"(%29, %28) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %31 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %32 = "neura.phi"(%31, %27) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %33 = neura.reserve : !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %34 = "neura.phi"(%33, %26) : (!neura.data<memref<?x1x128x1x1x128xi8>, i1>, !neura.data<memref<?x1x128x1x1x128xi8>, i1>) -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %35 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %36 = "neura.phi"(%35, %23) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %37 = neura.reserve : !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %38 = "neura.phi"(%37, %25) : (!neura.data<memref<?x1x1x1x1x128xi8>, i1>, !neura.data<memref<?x1x1x1x1x128xi8>, i1>) -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %39 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %40 = "neura.phi"(%39, %24) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %41 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %42 = "neura.phi"(%41, %23) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %43 = "neura.icmp"(%42, %40) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %44 = neura.grant_predicate %38, %43 : !neura.data<memref<?x1x1x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %45 = neura.grant_predicate %36, %43 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %46 = neura.grant_predicate %42, %43 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %47 = neura.grant_predicate %34, %43 : !neura.data<memref<?x1x128x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %48 = neura.grant_predicate %32, %43 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %49 = neura.grant_predicate %30, %43 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %50 = neura.grant_predicate %40, %43 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %51 = "neura.not"(%43) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %52 = neura.grant_predicate %32, %51 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %53 = neura.grant_predicate %30, %51 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %54 = neura.grant_predicate %40, %51 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %55 = neura.grant_predicate %36, %51 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %56 = neura.grant_predicate %38, %51 : !neura.data<memref<?x1x1x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %57 = neura.grant_predicate %34, %51 : !neura.data<memref<?x1x128x1x1x128xi8>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     %58 = neura.load_indexed %44[%45, %45, %45, %45, %45, %46 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x1x1x1x1x128xi8>, i1> : !neura.data<i8, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %58 to %47[%45, %45, %48, %45, %45, %46 : !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x1x128x1x1x128xi8>, i1> : !neura.data<i8, i1>
+// CTRL2DATA-NEXT:     %59 = "neura.add"(%46, %49) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %59 -> %41 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %50 -> %39 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %44 -> %37 : !neura.data<memref<?x1x1x1x1x128xi8>, i1> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %45 -> %35 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %47 -> %33 : !neura.data<memref<?x1x128x1x1x128xi8>, i1> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %48 -> %31 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %49 -> %29 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %60 = "neura.add"(%52, %53) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %60 -> %20 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %54 -> %18 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %55 -> %16 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %56 -> %14 : !neura.data<memref<?x1x1x1x1x128xi8>, i1> !neura.data<memref<?x1x1x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %57 -> %12 : !neura.data<memref<?x1x128x1x1x128xi8>, i1> !neura.data<memref<?x1x128x1x1x128xi8>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %53 -> %10 : !neura.data<i64, i1> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     "neura.return"() : () -> ()
 // CTRL2DATA-NEXT:   }

--- a/test/controflow_fuse/perfect_reduction/perfect_reduction.mlir
+++ b/test/controflow_fuse/perfect_reduction/perfect_reduction.mlir
@@ -103,7 +103,7 @@ module attributes {} {
 // CAST-NEXT:     "neura.return"(%5) : (i32) -> ()
 // CAST-NEXT:   }
 
-// CTRL2DATA: func.func @_Z27perfect_nested_reduction_2dPA128_i(%arg0: memref<?x128xi32>) -> i32 attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
+// CTRL2DATA:        func.func @_Z27perfect_nested_reduction_2dPA128_i(%arg0: memref<?x128xi32>) -> i32 attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
 // CTRL2DATA-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<memref<?x128xi32>, i1>
 // CTRL2DATA-NEXT:     %1 = "neura.grant_once"(%0) : (!neura.data<memref<?x128xi32>, i1>) -> !neura.data<memref<?x128xi32>, i1>
 // CTRL2DATA-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> !neura.data<i64, i1>
@@ -115,43 +115,71 @@ module attributes {} {
 // CTRL2DATA-NEXT:     %8 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %9 = "neura.grant_once"(%8) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %10 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %11 = "neura.phi"(%10, %5) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %12 = neura.reserve : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %13 = "neura.phi"(%12, %7) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %11 = "neura.phi"(%10, %3) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %12 = neura.reserve : !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %13 = "neura.phi"(%12, %1) : (!neura.data<memref<?x128xi32>, i1>, !neura.data<memref<?x128xi32>, i1>) -> !neura.data<memref<?x128xi32>, i1>
 // CTRL2DATA-NEXT:     %14 = neura.reserve : !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %15 = "neura.phi"(%14, %9) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %16 = "neura.icmp"(%15, %11) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %17 = neura.grant_predicate %9, %16 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %18 = neura.grant_predicate %13, %16 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %19 = "neura.not"(%16) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %20 = neura.grant_predicate %13, %19 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %21 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %22 = "neura.phi"(%21, %5) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %23 = neura.reserve : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %24 = "neura.phi"(%23, %18) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %25 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %26 = "neura.phi"(%25, %17) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %27 = "neura.icmp"(%26, %22) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %28 = neura.grant_predicate %1, %27 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
-// CTRL2DATA-NEXT:     %29 = neura.grant_predicate %15, %27 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %30 = neura.grant_predicate %26, %27 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %31 = neura.grant_predicate %24, %27 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %32 = neura.grant_predicate %3, %27 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %33 = neura.grant_predicate %5, %27 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %34 = "neura.not"(%27) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %35 = neura.grant_predicate %15, %34 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %36 = neura.grant_predicate %3, %34 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %37 = neura.grant_predicate %24, %34 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %38 = neura.grant_predicate %5, %34 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %39 = neura.load_indexed %28[%29, %30 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %40 = "neura.add"(%31, %39) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %41 = "neura.add"(%30, %32) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %41 -> %25 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %40 -> %23 : !neura.data<i32, i1> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %33 -> %21 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %42 = "neura.add"(%35, %36) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %42 -> %14 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %37 -> %12 : !neura.data<i32, i1> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %38 -> %10 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     "neura.return"(%20) : (!neura.data<i32, i1>) -> ()
+// CTRL2DATA-NEXT:     %16 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %17 = "neura.phi"(%16, %5) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %18 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %19 = "neura.phi"(%18, %7) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %20 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %21 = "neura.phi"(%20, %9) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %22 = "neura.icmp"(%21, %17) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %23 = neura.grant_predicate %15, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %24 = neura.grant_predicate %19, %22 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %25 = neura.grant_predicate %17, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %13, %22 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %27 = neura.grant_predicate %21, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %28 = neura.grant_predicate %11, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %29 = "neura.not"(%22) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %30 = neura.grant_predicate %19, %29 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %31 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %32 = "neura.phi"(%31, %23) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %33 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %34 = "neura.phi"(%33, %28) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %35 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %36 = "neura.phi"(%35, %27) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %37 = neura.reserve : !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %38 = "neura.phi"(%37, %26) : (!neura.data<memref<?x128xi32>, i1>, !neura.data<memref<?x128xi32>, i1>) -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %39 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %40 = "neura.phi"(%39, %25) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %41 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %42 = "neura.phi"(%41, %24) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %43 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %44 = "neura.phi"(%43, %23) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %45 = "neura.icmp"(%44, %40) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %46 = neura.grant_predicate %38, %45 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %47 = neura.grant_predicate %36, %45 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %48 = neura.grant_predicate %44, %45 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %49 = neura.grant_predicate %42, %45 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %50 = neura.grant_predicate %34, %45 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %51 = neura.grant_predicate %40, %45 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %52 = neura.grant_predicate %32, %45 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %53 = "neura.not"(%45) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %54 = neura.grant_predicate %36, %53 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %55 = neura.grant_predicate %34, %53 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %56 = neura.grant_predicate %42, %53 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %57 = neura.grant_predicate %40, %53 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %58 = neura.grant_predicate %32, %53 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %59 = neura.grant_predicate %38, %53 : !neura.data<memref<?x128xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     %60 = neura.load_indexed %46[%47, %48 : !neura.data<i64, i1>, !neura.data<i64, i1>] !neura.data<memref<?x128xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %61 = "neura.add"(%49, %60) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %62 = "neura.add"(%48, %50) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %62 -> %43 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %61 -> %41 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %51 -> %39 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %46 -> %37 : !neura.data<memref<?x128xi32>, i1> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %47 -> %35 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %50 -> %33 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %52 -> %31 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %63 = "neura.add"(%54, %55) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %63 -> %20 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %56 -> %18 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %57 -> %16 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %58 -> %14 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %59 -> %12 : !neura.data<memref<?x128xi32>, i1> !neura.data<memref<?x128xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %55 -> %10 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     "neura.return"(%30) : (!neura.data<i32, i1>) -> ()
 // CTRL2DATA-NEXT:   }

--- a/test/controflow_fuse/simple_loop/simple_loop.mlir
+++ b/test/controflow_fuse/simple_loop/simple_loop.mlir
@@ -18,7 +18,7 @@
 // RUN: --lower-builtin-to-neura \
 // RUN: --lower-llvm-to-neura \
 // RUN: --canonicalize-cast \
-// RUN: --canonicalize-live-in | FileCheck %s --check-prefix=CANO
+// RUN: --canonicalize-live-in | FileCheck %s --check-prefix=CANONICALIZE
 
 // RUN: mlir-neura-opt %t-llvm.mlir \
 // RUN: --assign-accelerator \
@@ -99,30 +99,30 @@ module attributes {} {
 // CHECK-NEXT:     "neura.return"() : () -> ()
 // CHECK-NEXT:   }
 
-// CANO:     func.func @_Z11simple_loopPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
-// CANO-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> memref<?xi32>
-// CANO-NEXT:     %1 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> memref<?xi32>
-// CANO-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> i64
-// CANO-NEXT:     %3 = "neura.constant"() <{predicate = true, value = 128 : i64}> : () -> i64
-// CANO-NEXT:     %4 = "neura.constant"() <{predicate = true, value = 1 : i32}> : () -> i32
-// CANO-NEXT:     %5 = "neura.constant"() <{predicate = true, value = 2 : i32}> : () -> i32
-// CANO-NEXT:     %6 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> i64
-// CANO-NEXT:     neura.br %6, %3 : i64, i64 to ^bb1
-// CANO-NEXT:   ^bb1(%7: i64, %8: i64):  // 2 preds: ^bb0, ^bb2
-// CANO-NEXT:     %9 = "neura.icmp"(%7, %8) <{cmpType = "slt"}> : (i64, i64) -> i1
-// CANO-NEXT:     neura.cond_br %9 : i1 then %0, %7, %5, %4, %1, %2, %3 : memref<?xi32>, i64, i32, i32, memref<?xi32>, i64, i64 to ^bb2 else to ^bb3
-// CANO-NEXT:   ^bb2(%10: memref<?xi32>, %11: i64, %12: i32, %13: i32, %14: memref<?xi32>, %15: i64, %16: i64):  // pred: ^bb1
-// CANO-NEXT:     %17 = neura.load_indexed %10[%11 : i64] memref<?xi32> : i32
-// CANO-NEXT:     %18 = "neura.mul"(%17, %12) : (i32, i32) -> i32
-// CANO-NEXT:     %19 = "neura.add"(%18, %13) : (i32, i32) -> i32
-// CANO-NEXT:     neura.store_indexed %19 to %14[%11 : i64] memref<?xi32> : i32
-// CANO-NEXT:     %20 = "neura.add"(%11, %15) : (i64, i64) -> i64
-// CANO-NEXT:     neura.br %20, %16 : i64, i64 to ^bb1
-// CANO-NEXT:   ^bb3:  // pred: ^bb1
-// CANO-NEXT:     "neura.return"() : () -> ()
-// CANO-NEXT:   }
+// CANONICALIZE:       func.func @_Z11simple_loopPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
+// CANONICALIZE-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> memref<?xi32>
+// CANONICALIZE-NEXT:     %1 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> memref<?xi32>
+// CANONICALIZE-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> i64
+// CANONICALIZE-NEXT:     %3 = "neura.constant"() <{predicate = true, value = 128 : i64}> : () -> i64
+// CANONICALIZE-NEXT:     %4 = "neura.constant"() <{predicate = true, value = 1 : i32}> : () -> i32
+// CANONICALIZE-NEXT:     %5 = "neura.constant"() <{predicate = true, value = 2 : i32}> : () -> i32
+// CANONICALIZE-NEXT:     %6 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> i64
+// CANONICALIZE-NEXT:     neura.br %6, %3, %0, %5, %4, %1, %2 : i64, i64, memref<?xi32>, i32, i32, memref<?xi32>, i64 to ^bb1
+// CANONICALIZE-NEXT:   ^bb1(%7: i64, %8: i64, %9: memref<?xi32>, %10: i32, %11: i32, %12: memref<?xi32>, %13: i64):  // 2 preds: ^bb0, ^bb2
+// CANONICALIZE-NEXT:     %14 = "neura.icmp"(%7, %8) <{cmpType = "slt"}> : (i64, i64) -> i1
+// CANONICALIZE-NEXT:     neura.cond_br %14 : i1 then %9, %7, %10, %11, %12, %13, %8 : memref<?xi32>, i64, i32, i32, memref<?xi32>, i64, i64 to ^bb2 else to ^bb3
+// CANONICALIZE-NEXT:   ^bb2(%15: memref<?xi32>, %16: i64, %17: i32, %18: i32, %19: memref<?xi32>, %20: i64, %21: i64):  // pred: ^bb1
+// CANONICALIZE-NEXT:     %22 = neura.load_indexed %15[%16 : i64] memref<?xi32> : i32
+// CANONICALIZE-NEXT:     %23 = "neura.mul"(%22, %17) : (i32, i32) -> i32
+// CANONICALIZE-NEXT:     %24 = "neura.add"(%23, %18) : (i32, i32) -> i32
+// CANONICALIZE-NEXT:     neura.store_indexed %24 to %19[%16 : i64] memref<?xi32> : i32
+// CANONICALIZE-NEXT:     %25 = "neura.add"(%16, %20) : (i64, i64) -> i64
+// CANONICALIZE-NEXT:     neura.br %25, %21, %15, %17, %18, %19, %20 : i64, i64, memref<?xi32>, i32, i32, memref<?xi32>, i64 to ^bb1
+// CANONICALIZE-NEXT:   ^bb3:  // pred: ^bb1
+// CANONICALIZE-NEXT:     "neura.return"() : () -> ()
+// CANONICALIZE-NEXT:   }
 
-// CTRL2DATA:      func.func @_Z11simple_loopPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
+// CTRL2DATA:        func.func @_Z11simple_loopPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
 // CTRL2DATA-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<memref<?xi32>, i1>
 // CTRL2DATA-NEXT:     %1 = "neura.grant_once"(%0) : (!neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
 // CTRL2DATA-NEXT:     %2 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<memref<?xi32>, i1>
@@ -138,25 +138,39 @@ module attributes {} {
 // CTRL2DATA-NEXT:     %12 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %13 = "neura.grant_once"(%12) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %14 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %15 = "neura.phi"(%14, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %16 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %17 = "neura.phi"(%16, %13) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %18 = "neura.icmp"(%17, %15) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %19 = "neura.not"(%18) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %20 = neura.grant_predicate %1, %18 : !neura.data<memref<?xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?xi32>, i1>
-// CTRL2DATA-NEXT:     %21 = neura.grant_predicate %17, %18 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %22 = neura.grant_predicate %11, %18 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %23 = neura.grant_predicate %9, %18 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %24 = neura.grant_predicate %3, %18 : !neura.data<memref<?xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?xi32>, i1>
-// CTRL2DATA-NEXT:     %25 = neura.grant_predicate %5, %18 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %7, %18 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %27 = neura.load_indexed %20[%21 : !neura.data<i64, i1>] !neura.data<memref<?xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %28 = "neura.mul"(%27, %22) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %29 = "neura.add"(%28, %23) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.store_indexed %29 to %24[%21 : !neura.data<i64, i1>] !neura.data<memref<?xi32>, i1> : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %30 = "neura.add"(%21, %25) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %30 -> %16 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %26 -> %14 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %15 = "neura.phi"(%14, %5) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %16 = neura.reserve : !neura.data<memref<?xi32>, i1>
+// CTRL2DATA-NEXT:     %17 = "neura.phi"(%16, %3) : (!neura.data<memref<?xi32>, i1>, !neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
+// CTRL2DATA-NEXT:     %18 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %19 = "neura.phi"(%18, %9) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %20 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %21 = "neura.phi"(%20, %11) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %22 = neura.reserve : !neura.data<memref<?xi32>, i1>
+// CTRL2DATA-NEXT:     %23 = "neura.phi"(%22, %1) : (!neura.data<memref<?xi32>, i1>, !neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
+// CTRL2DATA-NEXT:     %24 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %25 = "neura.phi"(%24, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %26 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %27 = "neura.phi"(%26, %13) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %28 = "neura.icmp"(%27, %25) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %29 = neura.grant_predicate %23, %28 : !neura.data<memref<?xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?xi32>, i1>
+// CTRL2DATA-NEXT:     %30 = neura.grant_predicate %27, %28 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %31 = neura.grant_predicate %21, %28 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %32 = neura.grant_predicate %19, %28 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %33 = neura.grant_predicate %17, %28 : !neura.data<memref<?xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?xi32>, i1>
+// CTRL2DATA-NEXT:     %34 = neura.grant_predicate %15, %28 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %35 = neura.grant_predicate %25, %28 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %36 = neura.load_indexed %29[%30 : !neura.data<i64, i1>] !neura.data<memref<?xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %37 = "neura.mul"(%36, %31) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %38 = "neura.add"(%37, %32) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.store_indexed %38 to %33[%30 : !neura.data<i64, i1>] !neura.data<memref<?xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %39 = "neura.add"(%30, %34) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %39 -> %26 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %35 -> %24 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %29 -> %22 : !neura.data<memref<?xi32>, i1> !neura.data<memref<?xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %31 -> %20 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %32 -> %18 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %33 -> %16 : !neura.data<memref<?xi32>, i1> !neura.data<memref<?xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %34 -> %14 : !neura.data<i64, i1> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     "neura.return"() : () -> ()
 // CTRL2DATA-NEXT:   }
 
@@ -171,58 +185,83 @@ module attributes {} {
 // FUSE-NEXT:     %6 = "neura.grant_once"() <{constant_value = 0 : i64}> : () -> !neura.data<i64, i1>
 // FUSE-NEXT:     %7 = "neura.grant_always"() <{constant_value = true}> : () -> !neura.data<i1, i1>
 // FUSE-NEXT:     %nextindex, %valid = neura.loop_control(parent_valid = %7, start = %6, end = %3, step = %2) {iterationType = "increment"} : !neura.data<i1, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1> -> !neura.data<i64, i1>, !neura.data<i1, i1>
-// FUSE-NEXT:     %8 = "neura.not"(%valid) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// FUSE-NEXT:     %9 = neura.grant_predicate %0, %valid : !neura.data<memref<?xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?xi32>, i1>
-// FUSE-NEXT:     %10 = neura.grant_predicate %5, %valid : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// FUSE-NEXT:     %11 = neura.grant_predicate %4, %valid : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// FUSE-NEXT:     %12 = neura.grant_predicate %1, %valid : !neura.data<memref<?xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?xi32>, i1>
-// FUSE-NEXT:     %13 = neura.load_indexed %9[%nextindex : !neura.data<i64, i1>] !neura.data<memref<?xi32>, i1> : !neura.data<i32, i1>
-// FUSE-NEXT:     %14 = "neura.mul"(%13, %10) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// FUSE-NEXT:     %15 = "neura.add"(%14, %11) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// FUSE-NEXT:     neura.store_indexed %15 to %12[%nextindex : !neura.data<i64, i1>] !neura.data<memref<?xi32>, i1> : !neura.data<i32, i1>
+// FUSE-NEXT:     %8 = neura.reserve : !neura.data<memref<?xi32>, i1>
+// FUSE-NEXT:     %9 = "neura.phi"(%8, %1) : (!neura.data<memref<?xi32>, i1>, !neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
+// FUSE-NEXT:     %10 = neura.reserve : !neura.data<i32, i1>
+// FUSE-NEXT:     %11 = "neura.phi"(%10, %4) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// FUSE-NEXT:     %12 = neura.reserve : !neura.data<i32, i1>
+// FUSE-NEXT:     %13 = "neura.phi"(%12, %5) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// FUSE-NEXT:     %14 = neura.reserve : !neura.data<memref<?xi32>, i1>
+// FUSE-NEXT:     %15 = "neura.phi"(%14, %0) : (!neura.data<memref<?xi32>, i1>, !neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
+// FUSE-NEXT:     %16 = neura.grant_predicate %15, %valid : !neura.data<memref<?xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?xi32>, i1>
+// FUSE-NEXT:     %17 = neura.grant_predicate %13, %valid : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// FUSE-NEXT:     %18 = neura.grant_predicate %11, %valid : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// FUSE-NEXT:     %19 = neura.grant_predicate %9, %valid : !neura.data<memref<?xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?xi32>, i1>
+// FUSE-NEXT:     %20 = neura.load_indexed %16[%nextindex : !neura.data<i64, i1>] !neura.data<memref<?xi32>, i1> : !neura.data<i32, i1>
+// FUSE-NEXT:     %21 = "neura.mul"(%20, %17) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// FUSE-NEXT:     %22 = "neura.add"(%21, %18) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// FUSE-NEXT:     neura.store_indexed %22 to %19[%nextindex : !neura.data<i64, i1>] !neura.data<memref<?xi32>, i1> : !neura.data<i32, i1>
+// FUSE-NEXT:     neura.ctrl_mov %16 -> %14 : !neura.data<memref<?xi32>, i1> !neura.data<memref<?xi32>, i1>
+// FUSE-NEXT:     neura.ctrl_mov %17 -> %12 : !neura.data<i32, i1> !neura.data<i32, i1>
+// FUSE-NEXT:     neura.ctrl_mov %18 -> %10 : !neura.data<i32, i1> !neura.data<i32, i1>
+// FUSE-NEXT:     neura.ctrl_mov %19 -> %8 : !neura.data<memref<?xi32>, i1> !neura.data<memref<?xi32>, i1>
 // FUSE-NEXT:     "neura.return"() : () -> ()
 // FUSE-NEXT:   }
 
-// FUSE-MAPPING:        func.func @_Z11simple_loopPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>, mapping_info = {compiled_ii = 5 : i32, mapping_mode = "spatial-temporal", mapping_strategy = "heuristic", rec_mii = 1 : i32, res_mii = 2 : i32, x_tiles = 4 : i32, y_tiles = 4 : i32}} {
-// FUSE-MAPPING-NEXT:     %0 = "neura.grant_once"() <{constant_value = "%arg0"}> {mapping_locs = [{id = 11 : i32, resource = "tile", time_step = 1 : i32, x = 3 : i32, y = 2 : i32}]} : () -> !neura.data<memref<?xi32>, i1>
-// FUSE-MAPPING-NEXT:     %1 = "neura.grant_once"() <{constant_value = "%arg1"}> {mapping_locs = [{id = 11 : i32, resource = "tile", time_step = 4 : i32, x = 3 : i32, y = 2 : i32}]} : () -> !neura.data<memref<?xi32>, i1>
-// FUSE-MAPPING-NEXT:     %2 = "neura.grant_always"() <{constant_value = 1 : i64}> {mapping_locs = [{id = 11 : i32, resource = "tile", time_step = 0 : i32, x = 3 : i32, y = 2 : i32}]} : () -> !neura.data<i64, i1>
-// FUSE-MAPPING-NEXT:     %3 = "neura.grant_always"() <{constant_value = 128 : i64}> {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 0 : i32, x = 1 : i32, y = 2 : i32}]} : () -> !neura.data<i64, i1>
-// FUSE-MAPPING-NEXT:     %4 = "neura.grant_once"() <{constant_value = 1 : i32}> {mapping_locs = [{id = 11 : i32, resource = "tile", time_step = 3 : i32, x = 3 : i32, y = 2 : i32}]} : () -> !neura.data<i32, i1>
-// FUSE-MAPPING-NEXT:     %5 = "neura.grant_once"() <{constant_value = 2 : i32}> {mapping_locs = [{id = 0 : i32, resource = "tile", time_step = 2 : i32, x = 0 : i32, y = 0 : i32}]} : () -> !neura.data<i32, i1>
-// FUSE-MAPPING-NEXT:     %6 = "neura.grant_once"() <{constant_value = 0 : i64}> {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 0 : i32, x = 2 : i32, y = 1 : i32}]} : () -> !neura.data<i64, i1>
-// FUSE-MAPPING-NEXT:     %7 = "neura.grant_always"() <{constant_value = true}> {mapping_locs = [{id = 4 : i32, resource = "tile", time_step = 0 : i32, x = 0 : i32, y = 1 : i32}]} : () -> !neura.data<i1, i1>
-// FUSE-MAPPING-NEXT:     %8 = "neura.data_mov"(%7) {mapping_locs = [{id = 10 : i32, resource = "link", time_step = 0 : i32}, {id = 14 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// FUSE-MAPPING-NEXT:     %9 = "neura.data_mov"(%6) {mapping_locs = [{id = 24 : i32, resource = "register", time_step = 0 : i32}, {id = 24 : i32, resource = "register", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// FUSE-MAPPING-NEXT:     %10 = "neura.data_mov"(%3) {mapping_locs = [{id = 28 : i32, resource = "link", time_step = 0 : i32}, {id = 33 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// FUSE-MAPPING-NEXT:     %11 = "neura.data_mov"(%2) {mapping_locs = [{id = 36 : i32, resource = "link", time_step = 0 : i32}, {id = 21 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// FUSE-MAPPING-NEXT:     %nextindex, %valid = neura.loop_control(parent_valid = %8, start = %9, end = %10, step = %11) {iterationType = "increment", mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 2 : i32, x = 2 : i32, y = 1 : i32}]} : !neura.data<i1, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1> -> !neura.data<i64, i1>, !neura.data<i1, i1>
-// FUSE-MAPPING-NEXT:     %12 = "neura.data_mov"(%valid) {mapping_locs = [{id = 25 : i32, resource = "register", time_step = 2 : i32}, {id = 25 : i32, resource = "register", time_step = 3 : i32}, {id = 25 : i32, resource = "register", time_step = 4 : i32}, {id = 25 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// FUSE-MAPPING-NEXT:     %13 = "neura.not"(%12) {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 6 : i32, x = 2 : i32, y = 1 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// FUSE-MAPPING-NEXT:     %14 = "neura.data_mov"(%0) {mapping_locs = [{id = 36 : i32, resource = "link", time_step = 1 : i32}, {id = 28 : i32, resource = "register", time_step = 2 : i32}]} : (!neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
-// FUSE-MAPPING-NEXT:     %15 = "neura.data_mov"(%valid) {mapping_locs = [{id = 18 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// FUSE-MAPPING-NEXT:     %16 = neura.grant_predicate %14, %15 {mapping_locs = [{id = 7 : i32, resource = "tile", time_step = 3 : i32, x = 3 : i32, y = 1 : i32}]} : !neura.data<memref<?xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?xi32>, i1>
-// FUSE-MAPPING-NEXT:     %17 = "neura.data_mov"(%5) {mapping_locs = [{id = 0 : i32, resource = "link", time_step = 2 : i32}, {id = 4 : i32, resource = "register", time_step = 3 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// FUSE-MAPPING-NEXT:     %18 = "neura.data_mov"(%valid) {mapping_locs = [{id = 17 : i32, resource = "link", time_step = 2 : i32}, {id = 15 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// FUSE-MAPPING-NEXT:     %19 = neura.grant_predicate %17, %18 {mapping_locs = [{id = 1 : i32, resource = "tile", time_step = 4 : i32, x = 1 : i32, y = 0 : i32}]} : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// FUSE-MAPPING-NEXT:     %20 = "neura.data_mov"(%4) {mapping_locs = [{id = 35 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// FUSE-MAPPING-NEXT:     %21 = "neura.data_mov"(%valid) {mapping_locs = [{id = 20 : i32, resource = "link", time_step = 2 : i32}, {id = 40 : i32, resource = "register", time_step = 3 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// FUSE-MAPPING-NEXT:     %22 = neura.grant_predicate %20, %21 {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 4 : i32, x = 2 : i32, y = 2 : i32}]} : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// FUSE-MAPPING-NEXT:     %23 = "neura.data_mov"(%1) {mapping_locs = [{id = 36 : i32, resource = "link", time_step = 4 : i32}]} : (!neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
-// FUSE-MAPPING-NEXT:     %24 = "neura.data_mov"(%valid) {mapping_locs = [{id = 19 : i32, resource = "link", time_step = 2 : i32}, {id = 6 : i32, resource = "link", time_step = 3 : i32}, {id = 9 : i32, resource = "link", time_step = 4 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// FUSE-MAPPING-NEXT:     %25 = neura.grant_predicate %23, %24 {mapping_locs = [{id = 7 : i32, resource = "tile", time_step = 5 : i32, x = 3 : i32, y = 1 : i32}]} : !neura.data<memref<?xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?xi32>, i1>
-// FUSE-MAPPING-NEXT:     %26 = "neura.data_mov"(%16) {mapping_locs = [{id = 21 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
-// FUSE-MAPPING-NEXT:     %27 = "neura.data_mov"(%nextindex) {mapping_locs = [{id = 24 : i32, resource = "register", time_step = 2 : i32}, {id = 24 : i32, resource = "register", time_step = 3 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// FUSE-MAPPING-NEXT:     %28 = neura.load_indexed %26[%27 : !neura.data<i64, i1>] !neura.data<memref<?xi32>, i1> {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 4 : i32, x = 2 : i32, y = 1 : i32}]} : !neura.data<i32, i1>
-// FUSE-MAPPING-NEXT:     %29 = "neura.data_mov"(%28) {mapping_locs = [{id = 17 : i32, resource = "link", time_step = 4 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// FUSE-MAPPING-NEXT:     %30 = "neura.data_mov"(%19) {mapping_locs = [{id = 4 : i32, resource = "link", time_step = 4 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// FUSE-MAPPING-NEXT:     %31 = "neura.mul"(%29, %30) {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 5 : i32, x = 1 : i32, y = 1 : i32}]} : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// FUSE-MAPPING-NEXT:     %32 = "neura.data_mov"(%31) {mapping_locs = [{id = 16 : i32, resource = "link", time_step = 5 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// FUSE-MAPPING-NEXT:     %33 = "neura.data_mov"(%22) {mapping_locs = [{id = 31 : i32, resource = "link", time_step = 4 : i32}, {id = 36 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// FUSE-MAPPING-NEXT:     %34 = "neura.add"(%32, %33) {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 6 : i32, x = 1 : i32, y = 2 : i32}]} : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// FUSE-MAPPING-NEXT:     %35 = "neura.data_mov"(%34) {mapping_locs = [{id = 28 : i32, resource = "link", time_step = 6 : i32}, {id = 33 : i32, resource = "link", time_step = 7 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
-// FUSE-MAPPING-NEXT:     %36 = "neura.data_mov"(%25) {mapping_locs = [{id = 21 : i32, resource = "link", time_step = 5 : i32}, {id = 26 : i32, resource = "register", time_step = 6 : i32}, {id = 26 : i32, resource = "register", time_step = 7 : i32}]} : (!neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
-// FUSE-MAPPING-NEXT:     %37 = "neura.data_mov"(%nextindex) {mapping_locs = [{id = 27 : i32, resource = "register", time_step = 2 : i32}, {id = 27 : i32, resource = "register", time_step = 3 : i32}, {id = 27 : i32, resource = "register", time_step = 4 : i32}, {id = 27 : i32, resource = "register", time_step = 5 : i32}, {id = 27 : i32, resource = "register", time_step = 6 : i32}, {id = 27 : i32, resource = "register", time_step = 7 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// FUSE-MAPPING-NEXT:     neura.store_indexed %35 to %36[%37 : !neura.data<i64, i1>] !neura.data<memref<?xi32>, i1> {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 8 : i32, x = 2 : i32, y = 1 : i32}]} : !neura.data<i32, i1>
-// FUSE-MAPPING-NEXT:     "neura.return"() {mapping_locs = [{id = 0 : i32, resource = "tile", time_step = 6 : i32, x = 0 : i32, y = 0 : i32}]} : () -> ()
+// FUSE-MAPPING:        func.func @_Z11simple_loopPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>, mapping_info = {compiled_ii = 4 : i32, mapping_mode = "spatial-temporal", mapping_strategy = "heuristic", rec_mii = 2 : i32, res_mii = 2 : i32, x_tiles = 4 : i32, y_tiles = 4 : i32}} {
+// FUSE-MAPPING-NEXT:     %0 = "neura.grant_once"() <{constant_value = "%arg0"}> {mapping_locs = [{id = 0 : i32, resource = "tile", time_step = 0 : i32, x = 0 : i32, y = 0 : i32}]} : () -> !neura.data<memref<?xi32>, i1>
+// FUSE-MAPPING-NEXT:     %1 = "neura.grant_once"() <{constant_value = "%arg1"}> {mapping_locs = [{id = 0 : i32, resource = "tile", time_step = 3 : i32, x = 0 : i32, y = 0 : i32}]} : () -> !neura.data<memref<?xi32>, i1>
+// FUSE-MAPPING-NEXT:     %2 = "neura.grant_always"() <{constant_value = 1 : i64}> {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 0 : i32, x = 1 : i32, y = 1 : i32}]} : () -> !neura.data<i64, i1>
+// FUSE-MAPPING-NEXT:     %3 = "neura.grant_always"() <{constant_value = 128 : i64}> {mapping_locs = [{id = 13 : i32, resource = "tile", time_step = 0 : i32, x = 1 : i32, y = 3 : i32}]} : () -> !neura.data<i64, i1>
+// FUSE-MAPPING-NEXT:     %4 = "neura.grant_once"() <{constant_value = 1 : i32}> {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 2 : i32, x = 2 : i32, y = 2 : i32}]} : () -> !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %5 = "neura.grant_once"() <{constant_value = 2 : i32}> {mapping_locs = [{id = 11 : i32, resource = "tile", time_step = 1 : i32, x = 3 : i32, y = 2 : i32}]} : () -> !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %6 = "neura.grant_once"() <{constant_value = 0 : i64}> {mapping_locs = [{id = 11 : i32, resource = "tile", time_step = 0 : i32, x = 3 : i32, y = 2 : i32}]} : () -> !neura.data<i64, i1>
+// FUSE-MAPPING-NEXT:     %7 = "neura.grant_always"() <{constant_value = true}> {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 0 : i32, x = 1 : i32, y = 2 : i32}]} : () -> !neura.data<i1, i1>
+// FUSE-MAPPING-NEXT:     %8 = "neura.data_mov"(%7) {mapping_locs = [{id = 36 : i32, resource = "register", time_step = 0 : i32}, {id = 36 : i32, resource = "register", time_step = 1 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// FUSE-MAPPING-NEXT:     %9 = "neura.data_mov"(%6) {mapping_locs = [{id = 35 : i32, resource = "link", time_step = 0 : i32}, {id = 31 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// FUSE-MAPPING-NEXT:     %10 = "neura.data_mov"(%3) {mapping_locs = [{id = 42 : i32, resource = "link", time_step = 0 : i32}, {id = 37 : i32, resource = "register", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// FUSE-MAPPING-NEXT:     %11 = "neura.data_mov"(%2) {mapping_locs = [{id = 16 : i32, resource = "link", time_step = 0 : i32}, {id = 38 : i32, resource = "register", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// FUSE-MAPPING-NEXT:     %nextindex, %valid = neura.loop_control(parent_valid = %8, start = %9, end = %10, step = %11) {iterationType = "increment", mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 2 : i32, x = 1 : i32, y = 2 : i32}]} : !neura.data<i1, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1> -> !neura.data<i64, i1>, !neura.data<i1, i1>
+// FUSE-MAPPING-NEXT:     %12 = neura.reserve : !neura.data<memref<?xi32>, i1>
+// FUSE-MAPPING-NEXT:     %13 = "neura.data_mov"(%1) {mapping_locs = [{id = 0 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
+// FUSE-MAPPING-NEXT:     %14 = "neura.phi"(%12, %13) {mapping_locs = [{id = 1 : i32, resource = "tile", time_step = 4 : i32, x = 1 : i32, y = 0 : i32}]} : (!neura.data<memref<?xi32>, i1>, !neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
+// FUSE-MAPPING-NEXT:     %15 = neura.reserve : !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %16 = "neura.data_mov"(%4) {mapping_locs = [{id = 40 : i32, resource = "register", time_step = 2 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %17 = "neura.phi"(%15, %16) {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 3 : i32, x = 2 : i32, y = 2 : i32}]} : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %18 = neura.reserve : !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %19 = "neura.data_mov"(%5) {mapping_locs = [{id = 44 : i32, resource = "register", time_step = 1 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %20 = "neura.phi"(%18, %19) {mapping_locs = [{id = 11 : i32, resource = "tile", time_step = 2 : i32, x = 3 : i32, y = 2 : i32}]} : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %21 = neura.reserve : !neura.data<memref<?xi32>, i1>
+// FUSE-MAPPING-NEXT:     %22 = "neura.data_mov"(%0) {mapping_locs = [{id = 0 : i32, resource = "link", time_step = 0 : i32}]} : (!neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
+// FUSE-MAPPING-NEXT:     %23 = "neura.phi"(%21, %22) {mapping_locs = [{id = 1 : i32, resource = "tile", time_step = 1 : i32, x = 1 : i32, y = 0 : i32}]} : (!neura.data<memref<?xi32>, i1>, !neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
+// FUSE-MAPPING-NEXT:     %24 = "neura.data_mov"(%23) {mapping_locs = [{id = 4 : i32, resource = "link", time_step = 1 : i32}, {id = 20 : i32, resource = "register", time_step = 2 : i32}]} : (!neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
+// FUSE-MAPPING-NEXT:     %25 = "neura.data_mov"(%valid) {mapping_locs = [{id = 29 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// FUSE-MAPPING-NEXT:     %26 = neura.grant_predicate %24, %25 {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 3 : i32, x = 1 : i32, y = 1 : i32}]} : !neura.data<memref<?xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?xi32>, i1>
+// FUSE-MAPPING-NEXT:     %27 = "neura.data_mov"(%20) {mapping_locs = [{id = 35 : i32, resource = "link", time_step = 2 : i32}, {id = 40 : i32, resource = "register", time_step = 3 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %28 = "neura.data_mov"(%valid) {mapping_locs = [{id = 28 : i32, resource = "link", time_step = 2 : i32}, {id = 41 : i32, resource = "register", time_step = 3 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// FUSE-MAPPING-NEXT:     %29 = neura.grant_predicate %27, %28 {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 4 : i32, x = 2 : i32, y = 2 : i32}]} : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %30 = "neura.data_mov"(%17) {mapping_locs = [{id = 31 : i32, resource = "link", time_step = 3 : i32}, {id = 37 : i32, resource = "register", time_step = 4 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %31 = "neura.data_mov"(%valid) {mapping_locs = [{id = 38 : i32, resource = "register", time_step = 2 : i32}, {id = 38 : i32, resource = "register", time_step = 3 : i32}, {id = 38 : i32, resource = "register", time_step = 4 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// FUSE-MAPPING-NEXT:     %32 = neura.grant_predicate %30, %31 {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 5 : i32, x = 1 : i32, y = 2 : i32}]} : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %33 = "neura.data_mov"(%14) {mapping_locs = [{id = 3 : i32, resource = "link", time_step = 4 : i32}, {id = 8 : i32, resource = "register", time_step = 5 : i32}, {id = 8 : i32, resource = "register", time_step = 6 : i32}]} : (!neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
+// FUSE-MAPPING-NEXT:     %34 = "neura.data_mov"(%valid) {mapping_locs = [{id = 30 : i32, resource = "link", time_step = 2 : i32}, {id = 41 : i32, resource = "link", time_step = 3 : i32}, {id = 45 : i32, resource = "link", time_step = 4 : i32}, {id = 33 : i32, resource = "link", time_step = 5 : i32}, {id = 19 : i32, resource = "link", time_step = 6 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// FUSE-MAPPING-NEXT:     %35 = neura.grant_predicate %33, %34 {mapping_locs = [{id = 2 : i32, resource = "tile", time_step = 7 : i32, x = 2 : i32, y = 0 : i32}]} : !neura.data<memref<?xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?xi32>, i1>
+// FUSE-MAPPING-NEXT:     %36 = "neura.data_mov"(%26) {mapping_locs = [{id = 13 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
+// FUSE-MAPPING-NEXT:     %37 = "neura.data_mov"(%nextindex) {mapping_locs = [{id = 27 : i32, resource = "link", time_step = 2 : i32}, {id = 25 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// FUSE-MAPPING-NEXT:     %38 = neura.load_indexed %36[%37 : !neura.data<i64, i1>] !neura.data<memref<?xi32>, i1> {mapping_locs = [{id = 4 : i32, resource = "tile", time_step = 4 : i32, x = 0 : i32, y = 1 : i32}]} : !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %39 = "neura.data_mov"(%38) {mapping_locs = [{id = 10 : i32, resource = "link", time_step = 4 : i32}, {id = 20 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %40 = "neura.data_mov"(%29) {mapping_locs = [{id = 31 : i32, resource = "link", time_step = 4 : i32}, {id = 29 : i32, resource = "link", time_step = 5 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %41 = "neura.mul"(%39, %40) {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 6 : i32, x = 1 : i32, y = 1 : i32}]} : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %42 = "neura.data_mov"(%41) {mapping_locs = [{id = 14 : i32, resource = "link", time_step = 6 : i32}, {id = 20 : i32, resource = "link", time_step = 7 : i32}, {id = 34 : i32, resource = "link", time_step = 8 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %43 = "neura.data_mov"(%32) {mapping_locs = [{id = 30 : i32, resource = "link", time_step = 5 : i32}, {id = 41 : i32, resource = "link", time_step = 6 : i32}, {id = 56 : i32, resource = "register", time_step = 7 : i32}, {id = 56 : i32, resource = "register", time_step = 8 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %44 = "neura.add"(%42, %43) {mapping_locs = [{id = 14 : i32, resource = "tile", time_step = 9 : i32, x = 2 : i32, y = 3 : i32}]} : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %45 = "neura.data_mov"(%44) {mapping_locs = [{id = 43 : i32, resource = "link", time_step = 9 : i32}, {id = 42 : i32, resource = "link", time_step = 10 : i32}]} : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     %46 = "neura.data_mov"(%35) {mapping_locs = [{id = 7 : i32, resource = "link", time_step = 7 : i32}, {id = 17 : i32, resource = "link", time_step = 8 : i32}, {id = 16 : i32, resource = "link", time_step = 9 : i32}, {id = 36 : i32, resource = "register", time_step = 10 : i32}]} : (!neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
+// FUSE-MAPPING-NEXT:     %47 = "neura.data_mov"(%nextindex) {mapping_locs = [{id = 39 : i32, resource = "register", time_step = 2 : i32}, {id = 39 : i32, resource = "register", time_step = 3 : i32}, {id = 39 : i32, resource = "register", time_step = 4 : i32}, {id = 39 : i32, resource = "register", time_step = 5 : i32}, {id = 39 : i32, resource = "register", time_step = 6 : i32}, {id = 39 : i32, resource = "register", time_step = 7 : i32}, {id = 39 : i32, resource = "register", time_step = 8 : i32}, {id = 39 : i32, resource = "register", time_step = 9 : i32}, {id = 39 : i32, resource = "register", time_step = 10 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// FUSE-MAPPING-NEXT:     neura.store_indexed %45 to %46[%47 : !neura.data<i64, i1>] !neura.data<memref<?xi32>, i1> {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 11 : i32, x = 1 : i32, y = 2 : i32}]} : !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     neura.ctrl_mov %26 -> %21 {mapping_locs = [{id = 15 : i32, resource = "link", time_step = 3 : i32}, {id = 4 : i32, resource = "register", time_step = 4 : i32}]} : !neura.data<memref<?xi32>, i1> !neura.data<memref<?xi32>, i1>
+// FUSE-MAPPING-NEXT:     neura.ctrl_mov %29 -> %18 {mapping_locs = [{id = 32 : i32, resource = "link", time_step = 4 : i32}, {id = 45 : i32, resource = "register", time_step = 5 : i32}]} : !neura.data<i32, i1> !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     neura.ctrl_mov %32 -> %15 {mapping_locs = [{id = 28 : i32, resource = "link", time_step = 5 : i32}, {id = 41 : i32, resource = "register", time_step = 6 : i32}]} : !neura.data<i32, i1> !neura.data<i32, i1>
+// FUSE-MAPPING-NEXT:     neura.ctrl_mov %35 -> %12 {mapping_locs = [{id = 5 : i32, resource = "link", time_step = 7 : i32}]} : !neura.data<memref<?xi32>, i1> !neura.data<memref<?xi32>, i1>
+// FUSE-MAPPING-NEXT:     "neura.return"() {mapping_locs = [{id = 15 : i32, resource = "tile", time_step = 6 : i32, x = 3 : i32, y = 3 : i32}]} : () -> ()
 // FUSE-MAPPING-NEXT:   }

--- a/test/controflow_fuse/simple_loop_reduction/simple_loop_reduction.mlir
+++ b/test/controflow_fuse/simple_loop_reduction/simple_loop_reduction.mlir
@@ -17,7 +17,9 @@
 // RUN: --lower-memref-to-neura \
 // RUN: --lower-builtin-to-neura \
 // RUN: --lower-llvm-to-neura \
-// RUN: --canonicalize-cast | FileCheck %s --check-prefix=CAST
+// RUN: --canonicalize-cast \
+// RUN: --canonicalize-live-in \
+// RUN: | FileCheck %s --check-prefix=CANONICALIZE
 
 // RUN: mlir-neura-opt %t-llvm.mlir \
 // RUN: --assign-accelerator \
@@ -92,25 +94,25 @@ module attributes {} {
 // CHECK-NEXT:     "neura.return"(%6) : (i32) -> ()
 // CHECK-NEXT:   }
 
-// CAST:     func.func @_Z10simpleloopv() -> i32 attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
-// CAST-NEXT:     %0 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> i64
-// CAST-NEXT:     %1 = "neura.constant"() <{predicate = true, value = 128 : i64}> : () -> i64
-// CAST-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 0 : i32}> : () -> i32
-// CAST-NEXT:     %3 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> i64
-// CAST-NEXT:     neura.br %3, %2 : i64, i32 to ^bb1
-// CAST-NEXT:   ^bb1(%4: i64, %5: i32):  // 2 preds: ^bb0, ^bb2
-// CAST-NEXT:     %6 = "neura.icmp"(%4, %1) <{cmpType = "slt"}> : (i64, i64) -> i1
-// CAST-NEXT:     neura.cond_br %6 : i1 then to ^bb2 else to ^bb3
-// CAST-NEXT:   ^bb2:  // pred: ^bb1
-// CAST-NEXT:     %7 = "neura.cast"(%4) <{cast_type = "i64_to_i32"}> : (i64) -> i32
-// CAST-NEXT:     %8 = "neura.add"(%5, %7) : (i32, i32) -> i32
-// CAST-NEXT:     %9 = "neura.add"(%4, %0) : (i64, i64) -> i64
-// CAST-NEXT:     neura.br %9, %8 : i64, i32 to ^bb1
-// CAST-NEXT:   ^bb3:  // pred: ^bb1
-// CAST-NEXT:     "neura.return"(%5) : (i32) -> ()
-// CAST-NEXT:   }
+// CANONICALIZE:        func.func @_Z10simpleloopv() -> i32 attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
+// CANONICALIZE-NEXT:     %0 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> i64
+// CANONICALIZE-NEXT:     %1 = "neura.constant"() <{predicate = true, value = 128 : i64}> : () -> i64
+// CANONICALIZE-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 0 : i32}> : () -> i32
+// CANONICALIZE-NEXT:     %3 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> i64
+// CANONICALIZE-NEXT:     neura.br %3, %2, %1, %0 : i64, i32, i64, i64 to ^bb1
+// CANONICALIZE-NEXT:   ^bb1(%4: i64, %5: i32, %6: i64, %7: i64):  // 2 preds: ^bb0, ^bb2
+// CANONICALIZE-NEXT:     %8 = "neura.icmp"(%4, %6) <{cmpType = "slt"}> : (i64, i64) -> i1
+// CANONICALIZE-NEXT:     neura.cond_br %8 : i1 then %4, %5, %7, %6 : i64, i32, i64, i64 to ^bb2 else %5 : i32 to ^bb3
+// CANONICALIZE-NEXT:   ^bb2(%9: i64, %10: i32, %11: i64, %12: i64):  // pred: ^bb1
+// CANONICALIZE-NEXT:     %13 = "neura.cast"(%9) <{cast_type = "i64_to_i32"}> : (i64) -> i32
+// CANONICALIZE-NEXT:     %14 = "neura.add"(%10, %13) : (i32, i32) -> i32
+// CANONICALIZE-NEXT:     %15 = "neura.add"(%9, %11) : (i64, i64) -> i64
+// CANONICALIZE-NEXT:     neura.br %15, %14, %12, %11 : i64, i32, i64, i64 to ^bb1
+// CANONICALIZE-NEXT:   ^bb3(%16: i32):  // pred: ^bb1
+// CANONICALIZE-NEXT:     "neura.return"(%16) : (i32) -> ()
+// CANONICALIZE-NEXT:   }
 
-// CTRL2DATA: func.func @_Z10simpleloopv() -> i32 attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
+// CTRL2DATA:        func.func @_Z10simpleloopv() -> i32 attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
 // CTRL2DATA-NEXT:     %0 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %1 = "neura.grant_once"(%0) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 128 : i64}> : () -> !neura.data<i64, i1>
@@ -120,25 +122,28 @@ module attributes {} {
 // CTRL2DATA-NEXT:     %6 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %7 = "neura.grant_once"(%6) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %8 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %9 = "neura.phi"(%8, %3) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %10 = neura.reserve : !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %11 = "neura.phi"(%10, %5) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %12 = neura.reserve : !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %13 = "neura.phi"(%12, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %14 = "neura.icmp"(%13, %9) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %15 = neura.grant_predicate %13, %14 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %16 = neura.grant_predicate %11, %14 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %17 = neura.grant_predicate %1, %14 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %18 = neura.grant_predicate %3, %14 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %19 = "neura.not"(%14) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %20 = neura.grant_predicate %11, %19 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %21 = "neura.cast"(%15) <{cast_type = "i64_to_i32"}> : (!neura.data<i64, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %22 = "neura.add"(%16, %21) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     %23 = "neura.add"(%15, %17) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %23 -> %12 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %22 -> %10 : !neura.data<i32, i1> !neura.data<i32, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %18 -> %8 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     "neura.return"(%20) : (!neura.data<i32, i1>) -> ()
+// CTRL2DATA-NEXT:     %9 = "neura.phi"(%8, %1) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %10 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %11 = "neura.phi"(%10, %3) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %12 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %13 = "neura.phi"(%12, %5) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %14 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %15 = "neura.phi"(%14, %7) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %16 = "neura.icmp"(%15, %11) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %17 = neura.grant_predicate %15, %16 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %18 = neura.grant_predicate %13, %16 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %19 = neura.grant_predicate %9, %16 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %20 = neura.grant_predicate %11, %16 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %21 = "neura.not"(%16) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %22 = neura.grant_predicate %13, %21 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %23 = "neura.cast"(%17) <{cast_type = "i64_to_i32"}> : (!neura.data<i64, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %24 = "neura.add"(%18, %23) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %25 = "neura.add"(%17, %19) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %25 -> %14 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %24 -> %12 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %20 -> %10 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %19 -> %8 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     "neura.return"(%22) : (!neura.data<i32, i1>) -> ()
 // CTRL2DATA-NEXT:   }
 
 

--- a/test/mapping_quality/branch_for.mlir
+++ b/test/mapping_quality/branch_for.mlir
@@ -8,7 +8,6 @@
 // RUN:   --assign-accelerator \
 // RUN:   --lower-llvm-to-neura \
 // RUN:   --canonicalize-live-in \
-// RUN:   --leverage-predicated-value \
 // RUN:   | FileCheck %s -check-prefix=CANONICALIZE
 
 // RUN: mlir-neura-opt %s \
@@ -97,19 +96,19 @@ func.func @loop_test() -> f32 {
 // CHECK-NEXT: }
 
 // CANONICALIZE:        func.func @loop_test() -> f32 attributes {accelerator = "neura"} {
-// CANONICALIZE-NEXT:     %0 = "neura.constant"() <{predicate = true, value = 10 : i64}> : () -> !neura.data<i64, i1>
-// CANONICALIZE-NEXT:     %1 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
-// CANONICALIZE-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> !neura.data<i64, i1>
-// CANONICALIZE-NEXT:     %3 = "neura.constant"() <{predicate = true, value = 3.000000e+00 : f32}> : () -> !neura.data<f32, i1>
-// CANONICALIZE-NEXT:     %4 = "neura.constant"() <{predicate = true, value = 0.000000e+00 : f32}> : () -> !neura.data<f32, i1>
-// CANONICALIZE-NEXT:     neura.br %1, %4, %3, %2, %0 : !neura.data<i64, i1>, !neura.data<f32, i1>, !neura.data<f32, i1>, !neura.data<i64, i1>, !neura.data<i64, i1> to ^bb1
-// CANONICALIZE-NEXT:   ^bb1(%5: !neura.data<i64, i1>, %6: !neura.data<f32, i1>, %7: !neura.data<f32, i1>, %8: !neura.data<i64, i1>, %9: !neura.data<i64, i1>):  // 2 preds: ^bb0, ^bb1
-// CANONICALIZE-NEXT:     %10 = "neura.fadd"(%6, %7) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CANONICALIZE-NEXT:     %11 = "neura.add"(%5, %8) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CANONICALIZE-NEXT:     %12 = "neura.icmp"(%11, %9) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CANONICALIZE-NEXT:     neura.cond_br %12 : !neura.data<i1, i1> then %11, %10, %3, %2, %0 : !neura.data<i64, i1>, !neura.data<f32, i1>, !neura.data<f32, i1>, !neura.data<i64, i1>, !neura.data<i64, i1> to ^bb1 else %10 : !neura.data<f32, i1> to ^bb2
-// CANONICALIZE-NEXT:   ^bb2(%13: !neura.data<f32, i1>):  // pred: ^bb1
-// CANONICALIZE-NEXT:     "neura.return"(%13) : (!neura.data<f32, i1>) -> ()
+// CANONICALIZE-NEXT:     %0 = "neura.constant"() <{predicate = true, value = 10 : i64}> : () -> i64
+// CANONICALIZE-NEXT:     %1 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> i64
+// CANONICALIZE-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> i64
+// CANONICALIZE-NEXT:     %3 = "neura.constant"() <{predicate = true, value = 3.000000e+00 : f32}> : () -> f32
+// CANONICALIZE-NEXT:     %4 = "neura.constant"() <{predicate = true, value = 0.000000e+00 : f32}> : () -> f32
+// CANONICALIZE-NEXT:     neura.br %1, %4, %3, %2, %0 : i64, f32, f32, i64, i64 to ^bb1
+// CANONICALIZE-NEXT:   ^bb1(%5: i64, %6: f32, %7: f32, %8: i64, %9: i64):  // 2 preds: ^bb0, ^bb1
+// CANONICALIZE-NEXT:     %10 = "neura.fadd"(%6, %7) : (f32, f32) -> f32
+// CANONICALIZE-NEXT:     %11 = "neura.add"(%5, %8) : (i64, i64) -> i64
+// CANONICALIZE-NEXT:     %12 = "neura.icmp"(%11, %9) <{cmpType = "slt"}> : (i64, i64) -> i1
+// CANONICALIZE-NEXT:     neura.cond_br %12 : i1 then %11, %10, %7, %8, %9 : i64, f32, f32, i64, i64 to ^bb1 else %10 : f32 to ^bb2
+// CANONICALIZE-NEXT:   ^bb2(%13: f32):  // pred: ^bb1
+// CANONICALIZE-NEXT:     "neura.return"(%13) : (f32) -> ()
 // CANONICALIZE-NEXT:   }
 
 // CTRL2DATA:        func.func @loop_test() -> f32 attributes {accelerator = "neura"} {
@@ -140,50 +139,50 @@ func.func @loop_test() -> f32 {
 // CTRL2DATA-NEXT:     neura.ctrl_mov %23 -> %18 : !neura.data<i64, i1> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %24 = neura.grant_predicate %20, %22 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
 // CTRL2DATA-NEXT:     neura.ctrl_mov %24 -> %16 : !neura.data<f32, i1> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %25 = neura.grant_predicate %7, %22 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %25 = neura.grant_predicate %15, %22 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
 // CTRL2DATA-NEXT:     neura.ctrl_mov %25 -> %14 : !neura.data<f32, i1> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %5, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %13, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     neura.ctrl_mov %26 -> %12 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %27 = neura.grant_predicate %1, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %27 = neura.grant_predicate %11, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     neura.ctrl_mov %27 -> %10 : !neura.data<i64, i1> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %28 = "neura.not"(%22) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
 // CTRL2DATA-NEXT:     %29 = neura.grant_predicate %20, %28 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
 // CTRL2DATA-NEXT:     "neura.return"(%29) : (!neura.data<f32, i1>) -> ()
 // CTRL2DATA-NEXT:   }
 
-// FUSE:        func.func @loop_test() -> f32 attributes {accelerator = "neura"} {
-// FUSE-NEXT:     %0 = "neura.grant_once"() <{constant_value = 10 : i64}> : () -> !neura.data<i64, i1>
-// FUSE-NEXT:     %1 = "neura.grant_once"() <{constant_value = 0 : i64}> : () -> !neura.data<i64, i1>
-// FUSE-NEXT:     %2 = "neura.grant_once"() <{constant_value = 1 : i64}> : () -> !neura.data<i64, i1>
-// FUSE-NEXT:     %3 = "neura.grant_once"() <{constant_value = 3.000000e+00 : f32}> : () -> !neura.data<f32, i1>
-// FUSE-NEXT:     %4 = "neura.grant_once"() <{constant_value = 0.000000e+00 : f32}> : () -> !neura.data<f32, i1>
-// FUSE-NEXT:     %5 = neura.reserve : !neura.data<i64, i1>
-// FUSE-NEXT:     %6 = "neura.phi"(%5, %0) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// FUSE-NEXT:     %7 = neura.reserve : !neura.data<i64, i1>
-// FUSE-NEXT:     %8 = "neura.phi"(%7, %2) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// FUSE-NEXT:     %9 = neura.reserve : !neura.data<f32, i1>
-// FUSE-NEXT:     %10 = "neura.phi"(%9, %3) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// FUSE-NEXT:     %11 = neura.reserve : !neura.data<f32, i1>
-// FUSE-NEXT:     %12 = "neura.phi"(%11, %4) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// FUSE-NEXT:     %13 = neura.reserve : !neura.data<i64, i1>
-// FUSE-NEXT:     %14 = "neura.phi"(%13, %1) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// FUSE-NEXT:     %15 = "neura.fadd"(%12, %10) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// FUSE-NEXT:     %16 = "neura.add"(%14, %8) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// FUSE-NEXT:     %17 = "neura.icmp"(%16, %6) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// FUSE-NEXT:     %18 = neura.grant_predicate %16, %17 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// FUSE-NEXT:     neura.ctrl_mov %18 -> %13 : !neura.data<i64, i1> !neura.data<i64, i1>
-// FUSE-NEXT:     %19 = neura.grant_predicate %15, %17 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// FUSE-NEXT:     neura.ctrl_mov %19 -> %11 : !neura.data<f32, i1> !neura.data<f32, i1>
-// FUSE-NEXT:     %20 = neura.grant_predicate %3, %17 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// FUSE-NEXT:     neura.ctrl_mov %20 -> %9 : !neura.data<f32, i1> !neura.data<f32, i1>
-// FUSE-NEXT:     %21 = neura.grant_predicate %2, %17 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// FUSE-NEXT:     neura.ctrl_mov %21 -> %7 : !neura.data<i64, i1> !neura.data<i64, i1>
-// FUSE-NEXT:     %22 = neura.grant_predicate %0, %17 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// FUSE-NEXT:     neura.ctrl_mov %22 -> %5 : !neura.data<i64, i1> !neura.data<i64, i1>
-// FUSE-NEXT:     %23 = "neura.not"(%17) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// FUSE-NEXT:     %24 = neura.grant_predicate %15, %23 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// FUSE-NEXT:     "neura.return"(%24) : (!neura.data<f32, i1>) -> ()
-// FUSE-NEXT:   }
+// FUSE:      func.func @loop_test() -> f32 attributes {accelerator = "neura"} {
+// FUSE-NEXT:   %0 = "neura.grant_once"() <{constant_value = 10 : i64}> : () -> !neura.data<i64, i1>
+// FUSE-NEXT:   %1 = "neura.grant_once"() <{constant_value = 0 : i64}> : () -> !neura.data<i64, i1>
+// FUSE-NEXT:   %2 = "neura.grant_once"() <{constant_value = 1 : i64}> : () -> !neura.data<i64, i1>
+// FUSE-NEXT:   %3 = "neura.grant_once"() <{constant_value = 3.000000e+00 : f32}> : () -> !neura.data<f32, i1>
+// FUSE-NEXT:   %4 = "neura.grant_once"() <{constant_value = 0.000000e+00 : f32}> : () -> !neura.data<f32, i1>
+// FUSE-NEXT:   %5 = neura.reserve : !neura.data<i64, i1>
+// FUSE-NEXT:   %6 = "neura.phi"(%5, %0) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// FUSE-NEXT:   %7 = neura.reserve : !neura.data<i64, i1>
+// FUSE-NEXT:   %8 = "neura.phi"(%7, %2) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// FUSE-NEXT:   %9 = neura.reserve : !neura.data<f32, i1>
+// FUSE-NEXT:   %10 = "neura.phi"(%9, %3) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// FUSE-NEXT:   %11 = neura.reserve : !neura.data<f32, i1>
+// FUSE-NEXT:   %12 = "neura.phi"(%11, %4) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// FUSE-NEXT:   %13 = neura.reserve : !neura.data<i64, i1>
+// FUSE-NEXT:   %14 = "neura.phi"(%13, %1) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// FUSE-NEXT:   %15 = "neura.fadd"(%12, %10) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// FUSE-NEXT:   %16 = "neura.add"(%14, %8) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// FUSE-NEXT:   %17 = "neura.icmp"(%16, %6) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// FUSE-NEXT:   %18 = neura.grant_predicate %16, %17 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// FUSE-NEXT:   neura.ctrl_mov %18 -> %13 : !neura.data<i64, i1> !neura.data<i64, i1>
+// FUSE-NEXT:   %19 = neura.grant_predicate %15, %17 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// FUSE-NEXT:   neura.ctrl_mov %19 -> %11 : !neura.data<f32, i1> !neura.data<f32, i1>
+// FUSE-NEXT:   %20 = neura.grant_predicate %10, %17 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// FUSE-NEXT:   neura.ctrl_mov %20 -> %9 : !neura.data<f32, i1> !neura.data<f32, i1>
+// FUSE-NEXT:   %21 = neura.grant_predicate %8, %17 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// FUSE-NEXT:   neura.ctrl_mov %21 -> %7 : !neura.data<i64, i1> !neura.data<i64, i1>
+// FUSE-NEXT:   %22 = neura.grant_predicate %6, %17 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// FUSE-NEXT:   neura.ctrl_mov %22 -> %5 : !neura.data<i64, i1> !neura.data<i64, i1>
+// FUSE-NEXT:   %23 = "neura.not"(%17) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// FUSE-NEXT:   %24 = neura.grant_predicate %15, %23 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// FUSE-NEXT:   "neura.return"(%24) : (!neura.data<f32, i1>) -> ()
+// FUSE-NEXT: }
 
 // MOV:        func.func @loop_test() -> f32 attributes {accelerator = "neura"} {
 // MOV-NEXT:     %0 = "neura.grant_once"() <{constant_value = 10 : i64}> : () -> !neura.data<i64, i1>
@@ -223,15 +222,15 @@ func.func @loop_test() -> f32 {
 // MOV-NEXT:     %33 = "neura.data_mov"(%28) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
 // MOV-NEXT:     %34 = neura.grant_predicate %32, %33 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
 // MOV-NEXT:     neura.ctrl_mov %34 -> %14 : !neura.data<f32, i1> !neura.data<f32, i1>
-// MOV-NEXT:     %35 = "neura.data_mov"(%3) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MOV-NEXT:     %35 = "neura.data_mov"(%13) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
 // MOV-NEXT:     %36 = "neura.data_mov"(%28) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
 // MOV-NEXT:     %37 = neura.grant_predicate %35, %36 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
 // MOV-NEXT:     neura.ctrl_mov %37 -> %11 : !neura.data<f32, i1> !neura.data<f32, i1>
-// MOV-NEXT:     %38 = "neura.data_mov"(%2) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %38 = "neura.data_mov"(%10) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
 // MOV-NEXT:     %39 = "neura.data_mov"(%28) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
 // MOV-NEXT:     %40 = neura.grant_predicate %38, %39 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
 // MOV-NEXT:     neura.ctrl_mov %40 -> %8 : !neura.data<i64, i1> !neura.data<i64, i1>
-// MOV-NEXT:     %41 = "neura.data_mov"(%0) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %41 = "neura.data_mov"(%7) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
 // MOV-NEXT:     %42 = "neura.data_mov"(%28) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
 // MOV-NEXT:     %43 = neura.grant_predicate %41, %42 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
 // MOV-NEXT:     neura.ctrl_mov %43 -> %5 : !neura.data<i64, i1> !neura.data<i64, i1>
@@ -244,63 +243,63 @@ func.func @loop_test() -> f32 {
 // MOV-NEXT:     "neura.return"(%49) : (!neura.data<f32, i1>) -> ()
 // MOV-NEXT:   }
 
-// MAPPING:        func.func @loop_test() -> f32 attributes {accelerator = "neura", mapping_info = {compiled_ii = 6 : i32, mapping_mode = "spatial-temporal", mapping_strategy = "heuristic", rec_mii = 4 : i32, res_mii = 2 : i32, x_tiles = 4 : i32, y_tiles = 4 : i32}} {
-// MAPPING-NEXT:     %0 = "neura.grant_once"() <{constant_value = 10 : i64}> {mapping_locs = [{id = 0 : i32, resource = "tile", time_step = 1 : i32, x = 0 : i32, y = 0 : i32}]} : () -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %1 = "neura.grant_once"() <{constant_value = 0 : i64}> {mapping_locs = [{id = 0 : i32, resource = "tile", time_step = 0 : i32, x = 0 : i32, y = 0 : i32}]} : () -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %2 = "neura.grant_once"() <{constant_value = 1 : i64}> {mapping_locs = [{id = 2 : i32, resource = "tile", time_step = 0 : i32, x = 2 : i32, y = 0 : i32}]} : () -> !neura.data<i64, i1>
+// MAPPING:        func.func @loop_test() -> f32 attributes {accelerator = "neura", mapping_info = {compiled_ii = 5 : i32, mapping_mode = "spatial-temporal", mapping_strategy = "heuristic", rec_mii = 4 : i32, res_mii = 2 : i32, x_tiles = 4 : i32, y_tiles = 4 : i32}} {
+// MAPPING-NEXT:     %0 = "neura.grant_once"() <{constant_value = 10 : i64}> {mapping_locs = [{id = 8 : i32, resource = "tile", time_step = 1 : i32, x = 0 : i32, y = 2 : i32}]} : () -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %1 = "neura.grant_once"() <{constant_value = 0 : i64}> {mapping_locs = [{id = 11 : i32, resource = "tile", time_step = 0 : i32, x = 3 : i32, y = 2 : i32}]} : () -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %2 = "neura.grant_once"() <{constant_value = 1 : i64}> {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 0 : i32, x = 1 : i32, y = 2 : i32}]} : () -> !neura.data<i64, i1>
 // MAPPING-NEXT:     %3 = "neura.grant_once"() <{constant_value = 3.000000e+00 : f32}> {mapping_locs = [{id = 4 : i32, resource = "tile", time_step = 2 : i32, x = 0 : i32, y = 1 : i32}]} : () -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %4 = "neura.grant_once"() <{constant_value = 0.000000e+00 : f32}> {mapping_locs = [{id = 15 : i32, resource = "tile", time_step = 2 : i32, x = 3 : i32, y = 3 : i32}]} : () -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %4 = "neura.grant_once"() <{constant_value = 0.000000e+00 : f32}> {mapping_locs = [{id = 8 : i32, resource = "tile", time_step = 2 : i32, x = 0 : i32, y = 2 : i32}]} : () -> !neura.data<f32, i1>
 // MAPPING-NEXT:     %5 = neura.reserve : !neura.data<i64, i1>
-// MAPPING-NEXT:     %6 = "neura.data_mov"(%0) {mapping_locs = [{id = 0 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %7 = "neura.phi"(%5, %6) {mapping_locs = [{id = 1 : i32, resource = "tile", time_step = 2 : i32, x = 1 : i32, y = 0 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %6 = "neura.data_mov"(%0) {mapping_locs = [{id = 24 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %7 = "neura.phi"(%5, %6) {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 2 : i32, x = 1 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
 // MAPPING-NEXT:     %8 = neura.reserve : !neura.data<i64, i1>
-// MAPPING-NEXT:     %9 = "neura.data_mov"(%2) {mapping_locs = [{id = 7 : i32, resource = "link", time_step = 0 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %10 = "neura.phi"(%8, %9) {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 1 : i32, x = 2 : i32, y = 1 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %9 = "neura.data_mov"(%2) {mapping_locs = [{id = 36 : i32, resource = "register", time_step = 0 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %10 = "neura.phi"(%8, %9) {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 1 : i32, x = 1 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
 // MAPPING-NEXT:     %11 = neura.reserve : !neura.data<f32, i1>
-// MAPPING-NEXT:     %12 = "neura.data_mov"(%3) {mapping_locs = [{id = 11 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %13 = "neura.phi"(%11, %12) {mapping_locs = [{id = 0 : i32, resource = "tile", time_step = 3 : i32, x = 0 : i32, y = 0 : i32}]} : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %12 = "neura.data_mov"(%3) {mapping_locs = [{id = 10 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %13 = "neura.phi"(%11, %12) {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 3 : i32, x = 1 : i32, y = 1 : i32}]} : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
 // MAPPING-NEXT:     %14 = neura.reserve : !neura.data<f32, i1>
-// MAPPING-NEXT:     %15 = "neura.data_mov"(%4) {mapping_locs = [{id = 47 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %16 = "neura.phi"(%14, %15) {mapping_locs = [{id = 11 : i32, resource = "tile", time_step = 3 : i32, x = 3 : i32, y = 2 : i32}]} : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %15 = "neura.data_mov"(%4) {mapping_locs = [{id = 32 : i32, resource = "register", time_step = 2 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %16 = "neura.phi"(%14, %15) {mapping_locs = [{id = 8 : i32, resource = "tile", time_step = 3 : i32, x = 0 : i32, y = 2 : i32}]} : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
 // MAPPING-NEXT:     %17 = neura.reserve : !neura.data<i64, i1>
-// MAPPING-NEXT:     %18 = "neura.data_mov"(%1) {mapping_locs = [{id = 0 : i32, resource = "link", time_step = 0 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %19 = "neura.phi"(%17, %18) {mapping_locs = [{id = 1 : i32, resource = "tile", time_step = 1 : i32, x = 1 : i32, y = 0 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %20 = "neura.data_mov"(%16) {mapping_locs = [{id = 35 : i32, resource = "link", time_step = 3 : i32}, {id = 31 : i32, resource = "link", time_step = 4 : i32}, {id = 36 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %21 = "neura.data_mov"(%13) {mapping_locs = [{id = 0 : i32, resource = "link", time_step = 3 : i32}, {id = 4 : i32, resource = "link", time_step = 4 : i32}, {id = 16 : i32, resource = "link", time_step = 5 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %22 = "neura.fadd"(%20, %21) {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 6 : i32, x = 1 : i32, y = 2 : i32}]} : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %23 = "neura.data_mov"(%19) {mapping_locs = [{id = 4 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %24 = "neura.data_mov"(%10) {mapping_locs = [{id = 17 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %25 = "neura.add"(%23, %24) {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 2 : i32, x = 1 : i32, y = 1 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %26 = "neura.data_mov"(%25) {mapping_locs = [{id = 20 : i32, resource = "register", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %27 = "neura.data_mov"(%7) {mapping_locs = [{id = 4 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %28 = "neura.icmp"(%26, %27) <{cmpType = "slt"}> {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 3 : i32, x = 1 : i32, y = 1 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:     %29 = "neura.data_mov"(%25) {mapping_locs = [{id = 21 : i32, resource = "register", time_step = 2 : i32}, {id = 21 : i32, resource = "register", time_step = 3 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %30 = "neura.data_mov"(%28) {mapping_locs = [{id = 20 : i32, resource = "register", time_step = 3 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:     %31 = neura.grant_predicate %29, %30 {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 4 : i32, x = 1 : i32, y = 1 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// MAPPING-NEXT:     neura.ctrl_mov %31 -> %17 {mapping_locs = [{id = 15 : i32, resource = "link", time_step = 4 : i32}, {id = 4 : i32, resource = "register", time_step = 5 : i32}, {id = 4 : i32, resource = "register", time_step = 6 : i32}]} : !neura.data<i64, i1> !neura.data<i64, i1>
-// MAPPING-NEXT:     %32 = "neura.data_mov"(%22) {mapping_locs = [{id = 36 : i32, resource = "register", time_step = 6 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %33 = "neura.data_mov"(%28) {mapping_locs = [{id = 16 : i32, resource = "link", time_step = 3 : i32}, {id = 37 : i32, resource = "register", time_step = 4 : i32}, {id = 37 : i32, resource = "register", time_step = 5 : i32}, {id = 37 : i32, resource = "register", time_step = 6 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:     %34 = neura.grant_predicate %32, %33 {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 7 : i32, x = 1 : i32, y = 2 : i32}]} : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// MAPPING-NEXT:     neura.ctrl_mov %34 -> %14 {mapping_locs = [{id = 28 : i32, resource = "link", time_step = 7 : i32}, {id = 32 : i32, resource = "link", time_step = 8 : i32}]} : !neura.data<f32, i1> !neura.data<f32, i1>
-// MAPPING-NEXT:     %35 = "neura.data_mov"(%3) {mapping_locs = [{id = 12 : i32, resource = "link", time_step = 2 : i32}, {id = 24 : i32, resource = "link", time_step = 3 : i32}, {id = 29 : i32, resource = "link", time_step = 4 : i32}, {id = 15 : i32, resource = "link", time_step = 5 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %36 = "neura.data_mov"(%28) {mapping_locs = [{id = 13 : i32, resource = "link", time_step = 3 : i32}, {id = 11 : i32, resource = "link", time_step = 4 : i32}, {id = 0 : i32, resource = "link", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:     %37 = neura.grant_predicate %35, %36 {mapping_locs = [{id = 1 : i32, resource = "tile", time_step = 6 : i32, x = 1 : i32, y = 0 : i32}]} : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// MAPPING-NEXT:     neura.ctrl_mov %37 -> %11 {mapping_locs = [{id = 2 : i32, resource = "link", time_step = 6 : i32}, {id = 0 : i32, resource = "register", time_step = 7 : i32}, {id = 0 : i32, resource = "register", time_step = 8 : i32}]} : !neura.data<f32, i1> !neura.data<f32, i1>
-// MAPPING-NEXT:     %38 = "neura.data_mov"(%2) {mapping_locs = [{id = 6 : i32, resource = "link", time_step = 0 : i32}, {id = 9 : i32, resource = "link", time_step = 1 : i32}, {id = 21 : i32, resource = "link", time_step = 2 : i32}, {id = 24 : i32, resource = "register", time_step = 3 : i32}, {id = 24 : i32, resource = "register", time_step = 4 : i32}, {id = 24 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %39 = "neura.data_mov"(%28) {mapping_locs = [{id = 14 : i32, resource = "link", time_step = 3 : i32}, {id = 25 : i32, resource = "register", time_step = 4 : i32}, {id = 25 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:     %40 = neura.grant_predicate %38, %39 {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 6 : i32, x = 2 : i32, y = 1 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// MAPPING-NEXT:     neura.ctrl_mov %40 -> %8 {mapping_locs = [{id = 24 : i32, resource = "register", time_step = 6 : i32}]} : !neura.data<i64, i1> !neura.data<i64, i1>
-// MAPPING-NEXT:     %41 = "neura.data_mov"(%0) {mapping_locs = [{id = 1 : i32, resource = "link", time_step = 1 : i32}, {id = 10 : i32, resource = "link", time_step = 2 : i32}, {id = 22 : i32, resource = "register", time_step = 3 : i32}, {id = 22 : i32, resource = "register", time_step = 4 : i32}, {id = 22 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %42 = "neura.data_mov"(%28) {mapping_locs = [{id = 23 : i32, resource = "register", time_step = 3 : i32}, {id = 23 : i32, resource = "register", time_step = 4 : i32}, {id = 23 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:     %43 = neura.grant_predicate %41, %42 {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 6 : i32, x = 1 : i32, y = 1 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// MAPPING-NEXT:     neura.ctrl_mov %43 -> %5 {mapping_locs = [{id = 15 : i32, resource = "link", time_step = 6 : i32}, {id = 4 : i32, resource = "register", time_step = 7 : i32}]} : !neura.data<i64, i1> !neura.data<i64, i1>
-// MAPPING-NEXT:     %44 = "neura.data_mov"(%28) {mapping_locs = [{id = 15 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:     %45 = "neura.not"(%44) {mapping_locs = [{id = 1 : i32, resource = "tile", time_step = 4 : i32, x = 1 : i32, y = 0 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:     %46 = "neura.data_mov"(%22) {mapping_locs = [{id = 27 : i32, resource = "link", time_step = 6 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %47 = "neura.data_mov"(%45) {mapping_locs = [{id = 2 : i32, resource = "link", time_step = 4 : i32}, {id = 1 : i32, resource = "link", time_step = 5 : i32}, {id = 12 : i32, resource = "link", time_step = 6 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:     %48 = neura.grant_predicate %46, %47 {mapping_locs = [{id = 8 : i32, resource = "tile", time_step = 7 : i32, x = 0 : i32, y = 2 : i32}]} : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %49 = "neura.data_mov"(%48) {mapping_locs = [{id = 32 : i32, resource = "register", time_step = 7 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:     "neura.return"(%49) {mapping_locs = [{id = 8 : i32, resource = "tile", time_step = 8 : i32, x = 0 : i32, y = 2 : i32}]} : (!neura.data<f32, i1>) -> ()
+// MAPPING-NEXT:     %18 = "neura.data_mov"(%1) {mapping_locs = [{id = 44 : i32, resource = "register", time_step = 0 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %19 = "neura.phi"(%17, %18) {mapping_locs = [{id = 11 : i32, resource = "tile", time_step = 1 : i32, x = 3 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %20 = "neura.data_mov"(%16) {mapping_locs = [{id = 24 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %21 = "neura.data_mov"(%13) {mapping_locs = [{id = 16 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %22 = "neura.fadd"(%20, %21) {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 4 : i32, x = 1 : i32, y = 2 : i32}]} : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %23 = "neura.data_mov"(%19) {mapping_locs = [{id = 35 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %24 = "neura.data_mov"(%10) {mapping_locs = [{id = 28 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %25 = "neura.add"(%23, %24) {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 2 : i32, x = 2 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %26 = "neura.data_mov"(%25) {mapping_locs = [{id = 40 : i32, resource = "register", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %27 = "neura.data_mov"(%7) {mapping_locs = [{id = 28 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %28 = "neura.icmp"(%26, %27) <{cmpType = "slt"}> {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 3 : i32, x = 2 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %29 = "neura.data_mov"(%25) {mapping_locs = [{id = 32 : i32, resource = "link", time_step = 2 : i32}, {id = 44 : i32, resource = "register", time_step = 3 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %30 = "neura.data_mov"(%28) {mapping_locs = [{id = 32 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %31 = neura.grant_predicate %29, %30 {mapping_locs = [{id = 11 : i32, resource = "tile", time_step = 4 : i32, x = 3 : i32, y = 2 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// MAPPING-NEXT:     neura.ctrl_mov %31 -> %17 {mapping_locs = [{id = 45 : i32, resource = "register", time_step = 4 : i32}, {id = 45 : i32, resource = "register", time_step = 5 : i32}]} : !neura.data<i64, i1> !neura.data<i64, i1>
+// MAPPING-NEXT:     %32 = "neura.data_mov"(%22) {mapping_locs = [{id = 30 : i32, resource = "link", time_step = 4 : i32}, {id = 52 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %33 = "neura.data_mov"(%28) {mapping_locs = [{id = 34 : i32, resource = "link", time_step = 3 : i32}, {id = 43 : i32, resource = "link", time_step = 4 : i32}, {id = 53 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %34 = neura.grant_predicate %32, %33 {mapping_locs = [{id = 13 : i32, resource = "tile", time_step = 6 : i32, x = 1 : i32, y = 3 : i32}]} : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// MAPPING-NEXT:     neura.ctrl_mov %34 -> %14 {mapping_locs = [{id = 40 : i32, resource = "link", time_step = 6 : i32}, {id = 39 : i32, resource = "link", time_step = 7 : i32}]} : !neura.data<f32, i1> !neura.data<f32, i1>
+// MAPPING-NEXT:     %35 = "neura.data_mov"(%13) {mapping_locs = [{id = 20 : i32, resource = "register", time_step = 3 : i32}, {id = 20 : i32, resource = "register", time_step = 4 : i32}, {id = 20 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %36 = "neura.data_mov"(%28) {mapping_locs = [{id = 31 : i32, resource = "link", time_step = 3 : i32}, {id = 29 : i32, resource = "link", time_step = 4 : i32}, {id = 21 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %37 = neura.grant_predicate %35, %36 {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 6 : i32, x = 1 : i32, y = 1 : i32}]} : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// MAPPING-NEXT:     neura.ctrl_mov %37 -> %11 {mapping_locs = [{id = 20 : i32, resource = "register", time_step = 6 : i32}, {id = 20 : i32, resource = "register", time_step = 7 : i32}]} : !neura.data<f32, i1> !neura.data<f32, i1>
+// MAPPING-NEXT:     %38 = "neura.data_mov"(%10) {mapping_locs = [{id = 29 : i32, resource = "link", time_step = 1 : i32}, {id = 14 : i32, resource = "link", time_step = 2 : i32}, {id = 24 : i32, resource = "register", time_step = 3 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %39 = "neura.data_mov"(%28) {mapping_locs = [{id = 33 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %40 = neura.grant_predicate %38, %39 {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 4 : i32, x = 2 : i32, y = 1 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// MAPPING-NEXT:     neura.ctrl_mov %40 -> %8 {mapping_locs = [{id = 17 : i32, resource = "link", time_step = 4 : i32}, {id = 16 : i32, resource = "link", time_step = 5 : i32}]} : !neura.data<i64, i1> !neura.data<i64, i1>
+// MAPPING-NEXT:     %41 = "neura.data_mov"(%7) {mapping_locs = [{id = 29 : i32, resource = "link", time_step = 2 : i32}, {id = 14 : i32, resource = "link", time_step = 3 : i32}, {id = 20 : i32, resource = "link", time_step = 4 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %42 = "neura.data_mov"(%28) {mapping_locs = [{id = 41 : i32, resource = "register", time_step = 3 : i32}, {id = 41 : i32, resource = "register", time_step = 4 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %43 = neura.grant_predicate %41, %42 {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 5 : i32, x = 2 : i32, y = 2 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// MAPPING-NEXT:     neura.ctrl_mov %43 -> %5 {mapping_locs = [{id = 31 : i32, resource = "link", time_step = 5 : i32}, {id = 36 : i32, resource = "register", time_step = 6 : i32}]} : !neura.data<i64, i1> !neura.data<i64, i1>
+// MAPPING-NEXT:     %44 = "neura.data_mov"(%28) {mapping_locs = [{id = 40 : i32, resource = "register", time_step = 3 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %45 = "neura.not"(%44) {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 4 : i32, x = 2 : i32, y = 2 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %46 = "neura.data_mov"(%22) {mapping_locs = [{id = 28 : i32, resource = "link", time_step = 4 : i32}, {id = 34 : i32, resource = "link", time_step = 5 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %47 = "neura.data_mov"(%45) {mapping_locs = [{id = 34 : i32, resource = "link", time_step = 4 : i32}, {id = 56 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %48 = neura.grant_predicate %46, %47 {mapping_locs = [{id = 14 : i32, resource = "tile", time_step = 6 : i32, x = 2 : i32, y = 3 : i32}]} : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %49 = "neura.data_mov"(%48) {mapping_locs = [{id = 43 : i32, resource = "link", time_step = 6 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     "neura.return"(%49) {mapping_locs = [{id = 13 : i32, resource = "tile", time_step = 7 : i32, x = 1 : i32, y = 3 : i32}]} : (!neura.data<f32, i1>) -> ()
 // MAPPING-NEXT:   }
 
 // INST:        "name": "neura.fadd",

--- a/test/mapping_quality/tiny_loop.mlir
+++ b/test/mapping_quality/tiny_loop.mlir
@@ -56,52 +56,52 @@ module {
   }
 }
 
-// CHECK:        func.func @simple_add_loop() -> i64 attributes {accelerator = "neura"} {
-// CHECK-NEXT:     %0 = "neura.constant"() <{predicate = true, value = 16 : i64}> : () -> i64
-// CHECK-NEXT:     %1 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> i64
-// CHECK-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> i64
-// CHECK-NEXT:     %3 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> i64
-// CHECK-NEXT:     neura.br %3, %2, %0 : i64, i64, i64 to ^bb1
-// CHECK-NEXT:   ^bb1(%4: i64, %5: i64, %6: i64):  // 2 preds: ^bb0, ^bb2
-// CHECK-NEXT:     %7 = "neura.icmp"(%4, %6) <{cmpType = "slt"}> : (i64, i64) -> i1
-// CHECK-NEXT:     neura.cond_br %7 : i1 then %5, %4, %1, %0 : i64, i64, i64, i64 to ^bb2 else %5 : i64 to ^bb3
-// CHECK-NEXT:   ^bb2(%8: i64, %9: i64, %10: i64, %11: i64):  // pred: ^bb1
-// CHECK-NEXT:     %12 = "neura.add"(%8, %8) : (i64, i64) -> i64
-// CHECK-NEXT:     %13 = "neura.add"(%9, %10) : (i64, i64) -> i64
-// CHECK-NEXT:     neura.br %13, %12, %11 : i64, i64, i64 to ^bb1
-// CHECK-NEXT:   ^bb3(%14: i64):  // pred: ^bb1
-// CHECK-NEXT:     "neura.return"(%14) : (i64) -> ()
-// CHECK-NEXT:   }
+// CHECK:     func.func @simple_add_loop() -> i64 attributes {accelerator = "neura"} {
+// CHECK-NEXT: %0 = "neura.constant"() <{predicate = true, value = 16 : i64}> : () -> i64
+// CHECK-NEXT: %1 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> i64
+// CHECK-NEXT: %2 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> i64
+// CHECK-NEXT: %3 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> i64
+// CHECK-NEXT: neura.br %3, %2, %0, %1 : i64, i64, i64, i64 to ^bb1
+// CHECK-NEXT: ^bb1(%4: i64, %5: i64, %6: i64, %7: i64):  // 2 preds: ^bb0, ^bb2
+// CHECK-NEXT: %8 = "neura.icmp"(%4, %6) <{cmpType = "slt"}> : (i64, i64) -> i1
+// CHECK-NEXT: neura.cond_br %8 : i1 then %5, %4, %7, %6 : i64, i64, i64, i64 to ^bb2 else %5 : i64 to ^bb3
+// CHECK-NEXT: ^bb2(%9: i64, %10: i64, %11: i64, %12: i64):  // pred: ^bb1
+// CHECK-NEXT: %13 = "neura.add"(%9, %9) : (i64, i64) -> i64
+// CHECK-NEXT: %14 = "neura.add"(%10, %11) : (i64, i64) -> i64
+// CHECK-NEXT: neura.br %14, %13, %12, %11 : i64, i64, i64, i64 to ^bb1
+// CHECK-NEXT: ^bb3(%15: i64):  // pred: ^bb1
+// CHECK-NEXT: "neura.return"(%15) : (i64) -> ()
+// CHECK-NEXT: }
 
-// SPATIAL:      func.func @simple_add_loop() -> i64 attributes {accelerator = "neura", mapping_info = {compiled_ii = 7 : i32, mapping_mode = "spatial-only", mapping_strategy = "heuristic", rec_mii = 3 : i32, res_mii = 1 : i32, x_tiles = 4 : i32, y_tiles = 4 : i32}} {
-// SPATIAL-NEXT:   %0 = "neura.grant_always"() <{constant_value = 16 : i64}> {mapping_locs = [{id = 2 : i32, resource = "tile", time_step = 0 : i32, x = 2 : i32, y = 0 : i32}]} : () -> !neura.data<i64, i1>
-// SPATIAL-NEXT:   %1 = "neura.grant_always"() <{constant_value = 1 : i64}> {mapping_locs = [{id = 0 : i32, resource = "tile", time_step = 0 : i32, x = 0 : i32, y = 0 : i32}]} : () -> !neura.data<i64, i1>
-// SPATIAL-NEXT:   %2 = "neura.grant_once"() <{constant_value = 1 : i64}> {mapping_locs = [{id = 1 : i32, resource = "tile", time_step = 1 : i32, x = 1 : i32, y = 0 : i32}]} : () -> !neura.data<i64, i1>
-// SPATIAL-NEXT:   %3 = "neura.grant_once"() <{constant_value = 0 : i64}> {mapping_locs = [{id = 11 : i32, resource = "tile", time_step = 0 : i32, x = 3 : i32, y = 2 : i32}]} : () -> !neura.data<i64, i1>
-// SPATIAL-NEXT:   %4 = "neura.grant_always"() <{constant_value = true}> {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 0 : i32, x = 2 : i32, y = 2 : i32}]} : () -> !neura.data<i1, i1>
-// SPATIAL-NEXT:   %5 = "neura.data_mov"(%4) {mapping_locs = [{id = 33 : i32, resource = "link", time_step = 0 : i32}, {id = 24 : i32, resource = "register", time_step = 1 : i32}, {id = 24 : i32, resource = "register", time_step = 2 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// SPATIAL-NEXT:   %6 = "neura.data_mov"(%3) {mapping_locs = [{id = 36 : i32, resource = "link", time_step = 0 : i32}, {id = 21 : i32, resource = "link", time_step = 1 : i32}, {id = 25 : i32, resource = "register", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// SPATIAL-NEXT:   %7 = "neura.data_mov"(%0) {mapping_locs = [{id = 7 : i32, resource = "link", time_step = 0 : i32}, {id = 26 : i32, resource = "register", time_step = 1 : i32}, {id = 26 : i32, resource = "register", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// SPATIAL-NEXT:   %8 = "neura.data_mov"(%1) {mapping_locs = [{id = 0 : i32, resource = "link", time_step = 0 : i32}, {id = 4 : i32, resource = "link", time_step = 1 : i32}, {id = 14 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// SPATIAL-NEXT:   %nextindex, %valid = neura.loop_control(parent_valid = %5, start = %6, end = %7, step = %8) {iterationType = "increment", mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 3 : i32, x = 2 : i32, y = 1 : i32}]} : !neura.data<i1, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1> -> !neura.data<i64, i1>, !neura.data<i1, i1>
-// SPATIAL-NEXT:   %9 = "neura.data_mov"(%valid) {mapping_locs = [{id = 18 : i32, resource = "link", time_step = 3 : i32}, {id = 22 : i32, resource = "link", time_step = 4 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// SPATIAL-NEXT:   %10 = "neura.not"(%9) {mapping_locs = [{id = 3 : i32, resource = "tile", time_step = 5 : i32, x = 3 : i32, y = 0 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// SPATIAL-NEXT:   %11 = neura.reserve : !neura.data<i64, i1>
-// SPATIAL-NEXT:   %12 = "neura.data_mov"(%2) {mapping_locs = [{id = 2 : i32, resource = "link", time_step = 1 : i32}, {id = 1 : i32, resource = "link", time_step = 2 : i32}, {id = 10 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// SPATIAL-NEXT:   %13 = "neura.phi"(%11, %12) {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 4 : i32, x = 1 : i32, y = 1 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// SPATIAL-NEXT:   %14 = "neura.data_mov"(%13) {mapping_locs = [{id = 16 : i32, resource = "link", time_step = 4 : i32}, {id = 36 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// SPATIAL-NEXT:   %15 = "neura.data_mov"(%valid) {mapping_locs = [{id = 20 : i32, resource = "link", time_step = 3 : i32}, {id = 31 : i32, resource = "link", time_step = 4 : i32}, {id = 37 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// SPATIAL-NEXT:   %16 = neura.grant_predicate %14, %15 {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 6 : i32, x = 1 : i32, y = 2 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// SPATIAL-NEXT:   %17 = "neura.data_mov"(%13) {mapping_locs = [{id = 13 : i32, resource = "link", time_step = 4 : i32}, {id = 12 : i32, resource = "link", time_step = 5 : i32}, {id = 24 : i32, resource = "link", time_step = 6 : i32}, {id = 28 : i32, resource = "link", time_step = 7 : i32}, {id = 34 : i32, resource = "link", time_step = 8 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// SPATIAL-NEXT:   %18 = "neura.data_mov"(%10) {mapping_locs = [{id = 9 : i32, resource = "link", time_step = 5 : i32}, {id = 23 : i32, resource = "link", time_step = 6 : i32}, {id = 37 : i32, resource = "link", time_step = 7 : i32}, {id = 46 : i32, resource = "link", time_step = 8 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// SPATIAL-NEXT:   %19 = neura.grant_predicate %17, %18 {mapping_locs = [{id = 14 : i32, resource = "tile", time_step = 9 : i32, x = 2 : i32, y = 3 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// SPATIAL-NEXT:   %20 = "neura.data_mov"(%16) {mapping_locs = [{id = 30 : i32, resource = "link", time_step = 6 : i32}, {id = 52 : i32, resource = "register", time_step = 7 : i32}, {id = 52 : i32, resource = "register", time_step = 8 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// SPATIAL-NEXT:   %21 = "neura.data_mov"(%16) {mapping_locs = [{id = 27 : i32, resource = "link", time_step = 6 : i32}, {id = 26 : i32, resource = "link", time_step = 7 : i32}, {id = 38 : i32, resource = "link", time_step = 8 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// SPATIAL-NEXT:   %22 = "neura.add"(%20, %21) {mapping_locs = [{id = 13 : i32, resource = "tile", time_step = 9 : i32, x = 1 : i32, y = 3 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// SPATIAL-NEXT:   neura.ctrl_mov %22 -> %11 {mapping_locs = [{id = 42 : i32, resource = "link", time_step = 9 : i32}, {id = 29 : i32, resource = "link", time_step = 10 : i32}]} : !neura.data<i64, i1> !neura.data<i64, i1>
-// SPATIAL-NEXT:   %23 = "neura.data_mov"(%19) {mapping_locs = [{id = 44 : i32, resource = "link", time_step = 9 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// SPATIAL-NEXT:   "neura.return"(%23) {mapping_locs = [{id = 15 : i32, resource = "tile", time_step = 10 : i32, x = 3 : i32, y = 3 : i32}]} : (!neura.data<i64, i1>) -> ()
-// SPATIAL-NEXT: }
+// SPATIAL:        func.func @simple_add_loop() -> i64 attributes {accelerator = "neura", mapping_info = {compiled_ii = 7 : i32, mapping_mode = "spatial-only", mapping_strategy = "heuristic", rec_mii = 3 : i32, res_mii = 1 : i32, x_tiles = 4 : i32, y_tiles = 4 : i32}} {
+// SPATIAL-NEXT:     %0 = "neura.grant_always"() <{constant_value = 16 : i64}> {mapping_locs = [{id = 2 : i32, resource = "tile", time_step = 0 : i32, x = 2 : i32, y = 0 : i32}]} : () -> !neura.data<i64, i1>
+// SPATIAL-NEXT:     %1 = "neura.grant_always"() <{constant_value = 1 : i64}> {mapping_locs = [{id = 0 : i32, resource = "tile", time_step = 0 : i32, x = 0 : i32, y = 0 : i32}]} : () -> !neura.data<i64, i1>
+// SPATIAL-NEXT:     %2 = "neura.grant_once"() <{constant_value = 1 : i64}> {mapping_locs = [{id = 1 : i32, resource = "tile", time_step = 1 : i32, x = 1 : i32, y = 0 : i32}]} : () -> !neura.data<i64, i1>
+// SPATIAL-NEXT:     %3 = "neura.grant_once"() <{constant_value = 0 : i64}> {mapping_locs = [{id = 11 : i32, resource = "tile", time_step = 0 : i32, x = 3 : i32, y = 2 : i32}]} : () -> !neura.data<i64, i1>
+// SPATIAL-NEXT:     %4 = "neura.grant_always"() <{constant_value = true}> {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 0 : i32, x = 2 : i32, y = 2 : i32}]} : () -> !neura.data<i1, i1>
+// SPATIAL-NEXT:     %5 = "neura.data_mov"(%4) {mapping_locs = [{id = 33 : i32, resource = "link", time_step = 0 : i32}, {id = 24 : i32, resource = "register", time_step = 1 : i32}, {id = 24 : i32, resource = "register", time_step = 2 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// SPATIAL-NEXT:     %6 = "neura.data_mov"(%3) {mapping_locs = [{id = 36 : i32, resource = "link", time_step = 0 : i32}, {id = 21 : i32, resource = "link", time_step = 1 : i32}, {id = 25 : i32, resource = "register", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// SPATIAL-NEXT:     %7 = "neura.data_mov"(%0) {mapping_locs = [{id = 7 : i32, resource = "link", time_step = 0 : i32}, {id = 26 : i32, resource = "register", time_step = 1 : i32}, {id = 26 : i32, resource = "register", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// SPATIAL-NEXT:     %8 = "neura.data_mov"(%1) {mapping_locs = [{id = 0 : i32, resource = "link", time_step = 0 : i32}, {id = 4 : i32, resource = "link", time_step = 1 : i32}, {id = 14 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// SPATIAL-NEXT:     %nextindex, %valid = neura.loop_control(parent_valid = %5, start = %6, end = %7, step = %8) {iterationType = "increment", mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 3 : i32, x = 2 : i32, y = 1 : i32}]} : !neura.data<i1, i1>, !neura.data<i64, i1>, !neura.data<i64, i1>, !neura.data<i64, i1> -> !neura.data<i64, i1>, !neura.data<i1, i1>
+// SPATIAL-NEXT:     %9 = "neura.data_mov"(%valid) {mapping_locs = [{id = 18 : i32, resource = "link", time_step = 3 : i32}, {id = 22 : i32, resource = "link", time_step = 4 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// SPATIAL-NEXT:     %10 = "neura.not"(%9) {mapping_locs = [{id = 3 : i32, resource = "tile", time_step = 5 : i32, x = 3 : i32, y = 0 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// SPATIAL-NEXT:     %11 = neura.reserve : !neura.data<i64, i1>
+// SPATIAL-NEXT:     %12 = "neura.data_mov"(%2) {mapping_locs = [{id = 2 : i32, resource = "link", time_step = 1 : i32}, {id = 1 : i32, resource = "link", time_step = 2 : i32}, {id = 10 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// SPATIAL-NEXT:     %13 = "neura.phi"(%11, %12) {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 4 : i32, x = 1 : i32, y = 1 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// SPATIAL-NEXT:     %14 = "neura.data_mov"(%13) {mapping_locs = [{id = 16 : i32, resource = "link", time_step = 4 : i32}, {id = 36 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// SPATIAL-NEXT:     %15 = "neura.data_mov"(%valid) {mapping_locs = [{id = 20 : i32, resource = "link", time_step = 3 : i32}, {id = 31 : i32, resource = "link", time_step = 4 : i32}, {id = 37 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// SPATIAL-NEXT:     %16 = neura.grant_predicate %14, %15 {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 6 : i32, x = 1 : i32, y = 2 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// SPATIAL-NEXT:     %17 = "neura.data_mov"(%13) {mapping_locs = [{id = 13 : i32, resource = "link", time_step = 4 : i32}, {id = 12 : i32, resource = "link", time_step = 5 : i32}, {id = 24 : i32, resource = "link", time_step = 6 : i32}, {id = 28 : i32, resource = "link", time_step = 7 : i32}, {id = 34 : i32, resource = "link", time_step = 8 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// SPATIAL-NEXT:     %18 = "neura.data_mov"(%10) {mapping_locs = [{id = 9 : i32, resource = "link", time_step = 5 : i32}, {id = 23 : i32, resource = "link", time_step = 6 : i32}, {id = 37 : i32, resource = "link", time_step = 7 : i32}, {id = 46 : i32, resource = "link", time_step = 8 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// SPATIAL-NEXT:     %19 = neura.grant_predicate %17, %18 {mapping_locs = [{id = 14 : i32, resource = "tile", time_step = 9 : i32, x = 2 : i32, y = 3 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// SPATIAL-NEXT:     %20 = "neura.data_mov"(%16) {mapping_locs = [{id = 30 : i32, resource = "link", time_step = 6 : i32}, {id = 52 : i32, resource = "register", time_step = 7 : i32}, {id = 52 : i32, resource = "register", time_step = 8 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// SPATIAL-NEXT:     %21 = "neura.data_mov"(%16) {mapping_locs = [{id = 27 : i32, resource = "link", time_step = 6 : i32}, {id = 26 : i32, resource = "link", time_step = 7 : i32}, {id = 38 : i32, resource = "link", time_step = 8 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// SPATIAL-NEXT:     %22 = "neura.add"(%20, %21) {mapping_locs = [{id = 13 : i32, resource = "tile", time_step = 9 : i32, x = 1 : i32, y = 3 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// SPATIAL-NEXT:     neura.ctrl_mov %22 -> %11 {mapping_locs = [{id = 42 : i32, resource = "link", time_step = 9 : i32}, {id = 29 : i32, resource = "link", time_step = 10 : i32}]} : !neura.data<i64, i1> !neura.data<i64, i1>
+// SPATIAL-NEXT:     %23 = "neura.data_mov"(%19) {mapping_locs = [{id = 44 : i32, resource = "link", time_step = 9 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// SPATIAL-NEXT:     "neura.return"(%23) {mapping_locs = [{id = 15 : i32, resource = "tile", time_step = 10 : i32, x = 3 : i32, y = 3 : i32}]} : (!neura.data<i64, i1>) -> ()
+// SPATIAL-NEXT:   }
 
 // SPATIAL-TEMPORAL:        func.func @simple_add_loop() -> i64 attributes {accelerator = "neura", mapping_info = {compiled_ii = 3 : i32, mapping_mode = "spatial-temporal", mapping_strategy = "heuristic", rec_mii = 3 : i32, res_mii = 1 : i32, x_tiles = 4 : i32, y_tiles = 4 : i32}} {
 // SPATIAL-TEMPORAL-NEXT:     %0 = "neura.grant_always"() <{constant_value = 16 : i64}> {mapping_locs = [{id = 4 : i32, resource = "tile", time_step = 0 : i32, x = 0 : i32, y = 1 : i32}]} : () -> !neura.data<i64, i1>

--- a/test/neura/ctrl/branch_for.mlir
+++ b/test/neura/ctrl/branch_for.mlir
@@ -8,7 +8,6 @@
 // RUN:   --assign-accelerator \
 // RUN:   --lower-llvm-to-neura \
 // RUN:   --canonicalize-live-in \
-// RUN:   --leverage-predicated-value \
 // RUN:   | FileCheck %s -check-prefix=CANONICALIZE
 
 // RUN: mlir-neura-opt %s \
@@ -97,19 +96,19 @@ func.func @loop_test() -> f32 {
 // CHECK-NEXT: }
 
 // CANONICALIZE:        func.func @loop_test() -> f32 attributes {accelerator = "neura"} {
-// CANONICALIZE-NEXT:     %0 = "neura.constant"() <{predicate = true, value = 10 : i64}> : () -> !neura.data<i64, i1>
-// CANONICALIZE-NEXT:     %1 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
-// CANONICALIZE-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> !neura.data<i64, i1>
-// CANONICALIZE-NEXT:     %3 = "neura.constant"() <{predicate = true, value = 3.000000e+00 : f32}> : () -> !neura.data<f32, i1>
-// CANONICALIZE-NEXT:     %4 = "neura.constant"() <{predicate = true, value = 0.000000e+00 : f32}> : () -> !neura.data<f32, i1>
-// CANONICALIZE-NEXT:     neura.br %1, %4, %3, %2, %0 : !neura.data<i64, i1>, !neura.data<f32, i1>, !neura.data<f32, i1>, !neura.data<i64, i1>, !neura.data<i64, i1> to ^bb1
-// CANONICALIZE-NEXT:   ^bb1(%5: !neura.data<i64, i1>, %6: !neura.data<f32, i1>, %7: !neura.data<f32, i1>, %8: !neura.data<i64, i1>, %9: !neura.data<i64, i1>):  // 2 preds: ^bb0, ^bb1
-// CANONICALIZE-NEXT:     %10 = "neura.fadd"(%6, %7) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CANONICALIZE-NEXT:     %11 = "neura.add"(%5, %8) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CANONICALIZE-NEXT:     %12 = "neura.icmp"(%11, %9) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CANONICALIZE-NEXT:     neura.cond_br %12 : !neura.data<i1, i1> then %11, %10, %3, %2, %0 : !neura.data<i64, i1>, !neura.data<f32, i1>, !neura.data<f32, i1>, !neura.data<i64, i1>, !neura.data<i64, i1> to ^bb1 else %10 : !neura.data<f32, i1> to ^bb2
-// CANONICALIZE-NEXT:   ^bb2(%13: !neura.data<f32, i1>):  // pred: ^bb1
-// CANONICALIZE-NEXT:     "neura.return"(%13) : (!neura.data<f32, i1>) -> ()
+// CANONICALIZE-NEXT:     %0 = "neura.constant"() <{predicate = true, value = 10 : i64}> : () -> i64
+// CANONICALIZE-NEXT:     %1 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> i64
+// CANONICALIZE-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> i64
+// CANONICALIZE-NEXT:     %3 = "neura.constant"() <{predicate = true, value = 3.000000e+00 : f32}> : () -> f32
+// CANONICALIZE-NEXT:     %4 = "neura.constant"() <{predicate = true, value = 0.000000e+00 : f32}> : () -> f32
+// CANONICALIZE-NEXT:     neura.br %1, %4, %3, %2, %0 : i64, f32, f32, i64, i64 to ^bb1
+// CANONICALIZE-NEXT:   ^bb1(%5: i64, %6: f32, %7: f32, %8: i64, %9: i64):  // 2 preds: ^bb0, ^bb1
+// CANONICALIZE-NEXT:     %10 = "neura.fadd"(%6, %7) : (f32, f32) -> f32
+// CANONICALIZE-NEXT:     %11 = "neura.add"(%5, %8) : (i64, i64) -> i64
+// CANONICALIZE-NEXT:     %12 = "neura.icmp"(%11, %9) <{cmpType = "slt"}> : (i64, i64) -> i1
+// CANONICALIZE-NEXT:     neura.cond_br %12 : i1 then %11, %10, %7, %8, %9 : i64, f32, f32, i64, i64 to ^bb1 else %10 : f32 to ^bb2
+// CANONICALIZE-NEXT:   ^bb2(%13: f32):  // pred: ^bb1
+// CANONICALIZE-NEXT:     "neura.return"(%13) : (f32) -> ()
 // CANONICALIZE-NEXT:   }
 
 // CTRL2DATA:        func.func @loop_test() -> f32 attributes {accelerator = "neura"} {
@@ -140,50 +139,50 @@ func.func @loop_test() -> f32 {
 // CTRL2DATA-NEXT:     neura.ctrl_mov %23 -> %18 : !neura.data<i64, i1> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %24 = neura.grant_predicate %20, %22 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
 // CTRL2DATA-NEXT:     neura.ctrl_mov %24 -> %16 : !neura.data<f32, i1> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %25 = neura.grant_predicate %7, %22 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %25 = neura.grant_predicate %15, %22 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
 // CTRL2DATA-NEXT:     neura.ctrl_mov %25 -> %14 : !neura.data<f32, i1> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %5, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %13, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     neura.ctrl_mov %26 -> %12 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CTRL2DATA-NEXT:     %27 = neura.grant_predicate %1, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %27 = neura.grant_predicate %11, %22 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     neura.ctrl_mov %27 -> %10 : !neura.data<i64, i1> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %28 = "neura.not"(%22) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
 // CTRL2DATA-NEXT:     %29 = neura.grant_predicate %20, %28 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
 // CTRL2DATA-NEXT:     "neura.return"(%29) : (!neura.data<f32, i1>) -> ()
 // CTRL2DATA-NEXT:   }
 
-// FUSE:        func.func @loop_test() -> f32 attributes {accelerator = "neura"} {
-// FUSE-NEXT:     %0 = "neura.grant_once"() <{constant_value = 10 : i64}> : () -> !neura.data<i64, i1>
-// FUSE-NEXT:     %1 = "neura.grant_once"() <{constant_value = 0 : i64}> : () -> !neura.data<i64, i1>
-// FUSE-NEXT:     %2 = "neura.grant_once"() <{constant_value = 1 : i64}> : () -> !neura.data<i64, i1>
-// FUSE-NEXT:     %3 = "neura.grant_once"() <{constant_value = 3.000000e+00 : f32}> : () -> !neura.data<f32, i1>
-// FUSE-NEXT:     %4 = "neura.grant_once"() <{constant_value = 0.000000e+00 : f32}> : () -> !neura.data<f32, i1>
-// FUSE-NEXT:     %5 = neura.reserve : !neura.data<i64, i1>
-// FUSE-NEXT:     %6 = "neura.phi"(%5, %0) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// FUSE-NEXT:     %7 = neura.reserve : !neura.data<i64, i1>
-// FUSE-NEXT:     %8 = "neura.phi"(%7, %2) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// FUSE-NEXT:     %9 = neura.reserve : !neura.data<f32, i1>
-// FUSE-NEXT:     %10 = "neura.phi"(%9, %3) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// FUSE-NEXT:     %11 = neura.reserve : !neura.data<f32, i1>
-// FUSE-NEXT:     %12 = "neura.phi"(%11, %4) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// FUSE-NEXT:     %13 = neura.reserve : !neura.data<i64, i1>
-// FUSE-NEXT:     %14 = "neura.phi"(%13, %1) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// FUSE-NEXT:     %15 = "neura.fadd"(%12, %10) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// FUSE-NEXT:     %16 = "neura.add"(%14, %8) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// FUSE-NEXT:     %17 = "neura.icmp"(%16, %6) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// FUSE-NEXT:     %18 = neura.grant_predicate %16, %17 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// FUSE-NEXT:     neura.ctrl_mov %18 -> %13 : !neura.data<i64, i1> !neura.data<i64, i1>
-// FUSE-NEXT:     %19 = neura.grant_predicate %15, %17 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// FUSE-NEXT:     neura.ctrl_mov %19 -> %11 : !neura.data<f32, i1> !neura.data<f32, i1>
-// FUSE-NEXT:     %20 = neura.grant_predicate %3, %17 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// FUSE-NEXT:     neura.ctrl_mov %20 -> %9 : !neura.data<f32, i1> !neura.data<f32, i1>
-// FUSE-NEXT:     %21 = neura.grant_predicate %2, %17 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// FUSE-NEXT:     neura.ctrl_mov %21 -> %7 : !neura.data<i64, i1> !neura.data<i64, i1>
-// FUSE-NEXT:     %22 = neura.grant_predicate %0, %17 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// FUSE-NEXT:     neura.ctrl_mov %22 -> %5 : !neura.data<i64, i1> !neura.data<i64, i1>
-// FUSE-NEXT:     %23 = "neura.not"(%17) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// FUSE-NEXT:     %24 = neura.grant_predicate %15, %23 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// FUSE-NEXT:     "neura.return"(%24) : (!neura.data<f32, i1>) -> ()
-// FUSE-NEXT:   }
+// FUSE:      func.func @loop_test() -> f32 attributes {accelerator = "neura"} {
+// FUSE-NEXT:   %0 = "neura.grant_once"() <{constant_value = 10 : i64}> : () -> !neura.data<i64, i1>
+// FUSE-NEXT:   %1 = "neura.grant_once"() <{constant_value = 0 : i64}> : () -> !neura.data<i64, i1>
+// FUSE-NEXT:   %2 = "neura.grant_once"() <{constant_value = 1 : i64}> : () -> !neura.data<i64, i1>
+// FUSE-NEXT:   %3 = "neura.grant_once"() <{constant_value = 3.000000e+00 : f32}> : () -> !neura.data<f32, i1>
+// FUSE-NEXT:   %4 = "neura.grant_once"() <{constant_value = 0.000000e+00 : f32}> : () -> !neura.data<f32, i1>
+// FUSE-NEXT:   %5 = neura.reserve : !neura.data<i64, i1>
+// FUSE-NEXT:   %6 = "neura.phi"(%5, %0) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// FUSE-NEXT:   %7 = neura.reserve : !neura.data<i64, i1>
+// FUSE-NEXT:   %8 = "neura.phi"(%7, %2) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// FUSE-NEXT:   %9 = neura.reserve : !neura.data<f32, i1>
+// FUSE-NEXT:   %10 = "neura.phi"(%9, %3) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// FUSE-NEXT:   %11 = neura.reserve : !neura.data<f32, i1>
+// FUSE-NEXT:   %12 = "neura.phi"(%11, %4) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// FUSE-NEXT:   %13 = neura.reserve : !neura.data<i64, i1>
+// FUSE-NEXT:   %14 = "neura.phi"(%13, %1) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// FUSE-NEXT:   %15 = "neura.fadd"(%12, %10) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// FUSE-NEXT:   %16 = "neura.add"(%14, %8) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// FUSE-NEXT:   %17 = "neura.icmp"(%16, %6) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// FUSE-NEXT:   %18 = neura.grant_predicate %16, %17 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// FUSE-NEXT:   neura.ctrl_mov %18 -> %13 : !neura.data<i64, i1> !neura.data<i64, i1>
+// FUSE-NEXT:   %19 = neura.grant_predicate %15, %17 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// FUSE-NEXT:   neura.ctrl_mov %19 -> %11 : !neura.data<f32, i1> !neura.data<f32, i1>
+// FUSE-NEXT:   %20 = neura.grant_predicate %10, %17 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// FUSE-NEXT:   neura.ctrl_mov %20 -> %9 : !neura.data<f32, i1> !neura.data<f32, i1>
+// FUSE-NEXT:   %21 = neura.grant_predicate %8, %17 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// FUSE-NEXT:   neura.ctrl_mov %21 -> %7 : !neura.data<i64, i1> !neura.data<i64, i1>
+// FUSE-NEXT:   %22 = neura.grant_predicate %6, %17 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// FUSE-NEXT:   neura.ctrl_mov %22 -> %5 : !neura.data<i64, i1> !neura.data<i64, i1>
+// FUSE-NEXT:   %23 = "neura.not"(%17) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// FUSE-NEXT:   %24 = neura.grant_predicate %15, %23 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// FUSE-NEXT:   "neura.return"(%24) : (!neura.data<f32, i1>) -> ()
+// FUSE-NEXT: }
 
 // MOV:        func.func @loop_test() -> f32 attributes {accelerator = "neura"} {
 // MOV-NEXT:     %0 = "neura.grant_once"() <{constant_value = 10 : i64}> : () -> !neura.data<i64, i1>
@@ -223,15 +222,15 @@ func.func @loop_test() -> f32 {
 // MOV-NEXT:     %33 = "neura.data_mov"(%28) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
 // MOV-NEXT:     %34 = neura.grant_predicate %32, %33 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
 // MOV-NEXT:     neura.ctrl_mov %34 -> %14 : !neura.data<f32, i1> !neura.data<f32, i1>
-// MOV-NEXT:     %35 = "neura.data_mov"(%3) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MOV-NEXT:     %35 = "neura.data_mov"(%13) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
 // MOV-NEXT:     %36 = "neura.data_mov"(%28) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
 // MOV-NEXT:     %37 = neura.grant_predicate %35, %36 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
 // MOV-NEXT:     neura.ctrl_mov %37 -> %11 : !neura.data<f32, i1> !neura.data<f32, i1>
-// MOV-NEXT:     %38 = "neura.data_mov"(%2) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %38 = "neura.data_mov"(%10) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
 // MOV-NEXT:     %39 = "neura.data_mov"(%28) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
 // MOV-NEXT:     %40 = neura.grant_predicate %38, %39 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
 // MOV-NEXT:     neura.ctrl_mov %40 -> %8 : !neura.data<i64, i1> !neura.data<i64, i1>
-// MOV-NEXT:     %41 = "neura.data_mov"(%0) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MOV-NEXT:     %41 = "neura.data_mov"(%7) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
 // MOV-NEXT:     %42 = "neura.data_mov"(%28) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
 // MOV-NEXT:     %43 = neura.grant_predicate %41, %42 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
 // MOV-NEXT:     neura.ctrl_mov %43 -> %5 : !neura.data<i64, i1> !neura.data<i64, i1>
@@ -244,63 +243,63 @@ func.func @loop_test() -> f32 {
 // MOV-NEXT:     "neura.return"(%49) : (!neura.data<f32, i1>) -> ()
 // MOV-NEXT:   }
 
-// MAPPING:        func.func @loop_test() -> f32 attributes {accelerator = "neura", mapping_info = {compiled_ii = 6 : i32, mapping_mode = "spatial-temporal", mapping_strategy = "heuristic", rec_mii = 4 : i32, res_mii = 2 : i32, x_tiles = 4 : i32, y_tiles = 4 : i32}} {
-// MAPPING-NEXT:     %0 = "neura.grant_once"() <{constant_value = 10 : i64}> {mapping_locs = [{id = 0 : i32, resource = "tile", time_step = 1 : i32, x = 0 : i32, y = 0 : i32}]} : () -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %1 = "neura.grant_once"() <{constant_value = 0 : i64}> {mapping_locs = [{id = 0 : i32, resource = "tile", time_step = 0 : i32, x = 0 : i32, y = 0 : i32}]} : () -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %2 = "neura.grant_once"() <{constant_value = 1 : i64}> {mapping_locs = [{id = 2 : i32, resource = "tile", time_step = 0 : i32, x = 2 : i32, y = 0 : i32}]} : () -> !neura.data<i64, i1>
+// MAPPING:        func.func @loop_test() -> f32 attributes {accelerator = "neura", mapping_info = {compiled_ii = 5 : i32, mapping_mode = "spatial-temporal", mapping_strategy = "heuristic", rec_mii = 4 : i32, res_mii = 2 : i32, x_tiles = 4 : i32, y_tiles = 4 : i32}} {
+// MAPPING-NEXT:     %0 = "neura.grant_once"() <{constant_value = 10 : i64}> {mapping_locs = [{id = 8 : i32, resource = "tile", time_step = 1 : i32, x = 0 : i32, y = 2 : i32}]} : () -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %1 = "neura.grant_once"() <{constant_value = 0 : i64}> {mapping_locs = [{id = 11 : i32, resource = "tile", time_step = 0 : i32, x = 3 : i32, y = 2 : i32}]} : () -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %2 = "neura.grant_once"() <{constant_value = 1 : i64}> {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 0 : i32, x = 1 : i32, y = 2 : i32}]} : () -> !neura.data<i64, i1>
 // MAPPING-NEXT:     %3 = "neura.grant_once"() <{constant_value = 3.000000e+00 : f32}> {mapping_locs = [{id = 4 : i32, resource = "tile", time_step = 2 : i32, x = 0 : i32, y = 1 : i32}]} : () -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %4 = "neura.grant_once"() <{constant_value = 0.000000e+00 : f32}> {mapping_locs = [{id = 15 : i32, resource = "tile", time_step = 2 : i32, x = 3 : i32, y = 3 : i32}]} : () -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %4 = "neura.grant_once"() <{constant_value = 0.000000e+00 : f32}> {mapping_locs = [{id = 8 : i32, resource = "tile", time_step = 2 : i32, x = 0 : i32, y = 2 : i32}]} : () -> !neura.data<f32, i1>
 // MAPPING-NEXT:     %5 = neura.reserve : !neura.data<i64, i1>
-// MAPPING-NEXT:     %6 = "neura.data_mov"(%0) {mapping_locs = [{id = 0 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %7 = "neura.phi"(%5, %6) {mapping_locs = [{id = 1 : i32, resource = "tile", time_step = 2 : i32, x = 1 : i32, y = 0 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %6 = "neura.data_mov"(%0) {mapping_locs = [{id = 24 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %7 = "neura.phi"(%5, %6) {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 2 : i32, x = 1 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
 // MAPPING-NEXT:     %8 = neura.reserve : !neura.data<i64, i1>
-// MAPPING-NEXT:     %9 = "neura.data_mov"(%2) {mapping_locs = [{id = 7 : i32, resource = "link", time_step = 0 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %10 = "neura.phi"(%8, %9) {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 1 : i32, x = 2 : i32, y = 1 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %9 = "neura.data_mov"(%2) {mapping_locs = [{id = 36 : i32, resource = "register", time_step = 0 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %10 = "neura.phi"(%8, %9) {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 1 : i32, x = 1 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
 // MAPPING-NEXT:     %11 = neura.reserve : !neura.data<f32, i1>
-// MAPPING-NEXT:     %12 = "neura.data_mov"(%3) {mapping_locs = [{id = 11 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %13 = "neura.phi"(%11, %12) {mapping_locs = [{id = 0 : i32, resource = "tile", time_step = 3 : i32, x = 0 : i32, y = 0 : i32}]} : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %12 = "neura.data_mov"(%3) {mapping_locs = [{id = 10 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %13 = "neura.phi"(%11, %12) {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 3 : i32, x = 1 : i32, y = 1 : i32}]} : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
 // MAPPING-NEXT:     %14 = neura.reserve : !neura.data<f32, i1>
-// MAPPING-NEXT:     %15 = "neura.data_mov"(%4) {mapping_locs = [{id = 47 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %16 = "neura.phi"(%14, %15) {mapping_locs = [{id = 11 : i32, resource = "tile", time_step = 3 : i32, x = 3 : i32, y = 2 : i32}]} : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %15 = "neura.data_mov"(%4) {mapping_locs = [{id = 32 : i32, resource = "register", time_step = 2 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %16 = "neura.phi"(%14, %15) {mapping_locs = [{id = 8 : i32, resource = "tile", time_step = 3 : i32, x = 0 : i32, y = 2 : i32}]} : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
 // MAPPING-NEXT:     %17 = neura.reserve : !neura.data<i64, i1>
-// MAPPING-NEXT:     %18 = "neura.data_mov"(%1) {mapping_locs = [{id = 0 : i32, resource = "link", time_step = 0 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %19 = "neura.phi"(%17, %18) {mapping_locs = [{id = 1 : i32, resource = "tile", time_step = 1 : i32, x = 1 : i32, y = 0 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %20 = "neura.data_mov"(%16) {mapping_locs = [{id = 35 : i32, resource = "link", time_step = 3 : i32}, {id = 31 : i32, resource = "link", time_step = 4 : i32}, {id = 36 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %21 = "neura.data_mov"(%13) {mapping_locs = [{id = 0 : i32, resource = "link", time_step = 3 : i32}, {id = 4 : i32, resource = "link", time_step = 4 : i32}, {id = 16 : i32, resource = "link", time_step = 5 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %22 = "neura.fadd"(%20, %21) {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 6 : i32, x = 1 : i32, y = 2 : i32}]} : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %23 = "neura.data_mov"(%19) {mapping_locs = [{id = 4 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %24 = "neura.data_mov"(%10) {mapping_locs = [{id = 17 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %25 = "neura.add"(%23, %24) {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 2 : i32, x = 1 : i32, y = 1 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %26 = "neura.data_mov"(%25) {mapping_locs = [{id = 20 : i32, resource = "register", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %27 = "neura.data_mov"(%7) {mapping_locs = [{id = 4 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %28 = "neura.icmp"(%26, %27) <{cmpType = "slt"}> {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 3 : i32, x = 1 : i32, y = 1 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:     %29 = "neura.data_mov"(%25) {mapping_locs = [{id = 21 : i32, resource = "register", time_step = 2 : i32}, {id = 21 : i32, resource = "register", time_step = 3 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %30 = "neura.data_mov"(%28) {mapping_locs = [{id = 20 : i32, resource = "register", time_step = 3 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:     %31 = neura.grant_predicate %29, %30 {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 4 : i32, x = 1 : i32, y = 1 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// MAPPING-NEXT:     neura.ctrl_mov %31 -> %17 {mapping_locs = [{id = 15 : i32, resource = "link", time_step = 4 : i32}, {id = 4 : i32, resource = "register", time_step = 5 : i32}, {id = 4 : i32, resource = "register", time_step = 6 : i32}]} : !neura.data<i64, i1> !neura.data<i64, i1>
-// MAPPING-NEXT:     %32 = "neura.data_mov"(%22) {mapping_locs = [{id = 36 : i32, resource = "register", time_step = 6 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %33 = "neura.data_mov"(%28) {mapping_locs = [{id = 16 : i32, resource = "link", time_step = 3 : i32}, {id = 37 : i32, resource = "register", time_step = 4 : i32}, {id = 37 : i32, resource = "register", time_step = 5 : i32}, {id = 37 : i32, resource = "register", time_step = 6 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:     %34 = neura.grant_predicate %32, %33 {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 7 : i32, x = 1 : i32, y = 2 : i32}]} : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// MAPPING-NEXT:     neura.ctrl_mov %34 -> %14 {mapping_locs = [{id = 28 : i32, resource = "link", time_step = 7 : i32}, {id = 32 : i32, resource = "link", time_step = 8 : i32}]} : !neura.data<f32, i1> !neura.data<f32, i1>
-// MAPPING-NEXT:     %35 = "neura.data_mov"(%3) {mapping_locs = [{id = 12 : i32, resource = "link", time_step = 2 : i32}, {id = 24 : i32, resource = "link", time_step = 3 : i32}, {id = 29 : i32, resource = "link", time_step = 4 : i32}, {id = 15 : i32, resource = "link", time_step = 5 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %36 = "neura.data_mov"(%28) {mapping_locs = [{id = 13 : i32, resource = "link", time_step = 3 : i32}, {id = 11 : i32, resource = "link", time_step = 4 : i32}, {id = 0 : i32, resource = "link", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:     %37 = neura.grant_predicate %35, %36 {mapping_locs = [{id = 1 : i32, resource = "tile", time_step = 6 : i32, x = 1 : i32, y = 0 : i32}]} : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// MAPPING-NEXT:     neura.ctrl_mov %37 -> %11 {mapping_locs = [{id = 2 : i32, resource = "link", time_step = 6 : i32}, {id = 0 : i32, resource = "register", time_step = 7 : i32}, {id = 0 : i32, resource = "register", time_step = 8 : i32}]} : !neura.data<f32, i1> !neura.data<f32, i1>
-// MAPPING-NEXT:     %38 = "neura.data_mov"(%2) {mapping_locs = [{id = 6 : i32, resource = "link", time_step = 0 : i32}, {id = 9 : i32, resource = "link", time_step = 1 : i32}, {id = 21 : i32, resource = "link", time_step = 2 : i32}, {id = 24 : i32, resource = "register", time_step = 3 : i32}, {id = 24 : i32, resource = "register", time_step = 4 : i32}, {id = 24 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %39 = "neura.data_mov"(%28) {mapping_locs = [{id = 14 : i32, resource = "link", time_step = 3 : i32}, {id = 25 : i32, resource = "register", time_step = 4 : i32}, {id = 25 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:     %40 = neura.grant_predicate %38, %39 {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 6 : i32, x = 2 : i32, y = 1 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// MAPPING-NEXT:     neura.ctrl_mov %40 -> %8 {mapping_locs = [{id = 24 : i32, resource = "register", time_step = 6 : i32}]} : !neura.data<i64, i1> !neura.data<i64, i1>
-// MAPPING-NEXT:     %41 = "neura.data_mov"(%0) {mapping_locs = [{id = 1 : i32, resource = "link", time_step = 1 : i32}, {id = 10 : i32, resource = "link", time_step = 2 : i32}, {id = 22 : i32, resource = "register", time_step = 3 : i32}, {id = 22 : i32, resource = "register", time_step = 4 : i32}, {id = 22 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// MAPPING-NEXT:     %42 = "neura.data_mov"(%28) {mapping_locs = [{id = 23 : i32, resource = "register", time_step = 3 : i32}, {id = 23 : i32, resource = "register", time_step = 4 : i32}, {id = 23 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:     %43 = neura.grant_predicate %41, %42 {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 6 : i32, x = 1 : i32, y = 1 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// MAPPING-NEXT:     neura.ctrl_mov %43 -> %5 {mapping_locs = [{id = 15 : i32, resource = "link", time_step = 6 : i32}, {id = 4 : i32, resource = "register", time_step = 7 : i32}]} : !neura.data<i64, i1> !neura.data<i64, i1>
-// MAPPING-NEXT:     %44 = "neura.data_mov"(%28) {mapping_locs = [{id = 15 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:     %45 = "neura.not"(%44) {mapping_locs = [{id = 1 : i32, resource = "tile", time_step = 4 : i32, x = 1 : i32, y = 0 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:     %46 = "neura.data_mov"(%22) {mapping_locs = [{id = 27 : i32, resource = "link", time_step = 6 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %47 = "neura.data_mov"(%45) {mapping_locs = [{id = 2 : i32, resource = "link", time_step = 4 : i32}, {id = 1 : i32, resource = "link", time_step = 5 : i32}, {id = 12 : i32, resource = "link", time_step = 6 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// MAPPING-NEXT:     %48 = neura.grant_predicate %46, %47 {mapping_locs = [{id = 8 : i32, resource = "tile", time_step = 7 : i32, x = 0 : i32, y = 2 : i32}]} : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// MAPPING-NEXT:     %49 = "neura.data_mov"(%48) {mapping_locs = [{id = 32 : i32, resource = "register", time_step = 7 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// MAPPING-NEXT:     "neura.return"(%49) {mapping_locs = [{id = 8 : i32, resource = "tile", time_step = 8 : i32, x = 0 : i32, y = 2 : i32}]} : (!neura.data<f32, i1>) -> ()
+// MAPPING-NEXT:     %18 = "neura.data_mov"(%1) {mapping_locs = [{id = 44 : i32, resource = "register", time_step = 0 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %19 = "neura.phi"(%17, %18) {mapping_locs = [{id = 11 : i32, resource = "tile", time_step = 1 : i32, x = 3 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %20 = "neura.data_mov"(%16) {mapping_locs = [{id = 24 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %21 = "neura.data_mov"(%13) {mapping_locs = [{id = 16 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %22 = "neura.fadd"(%20, %21) {mapping_locs = [{id = 9 : i32, resource = "tile", time_step = 4 : i32, x = 1 : i32, y = 2 : i32}]} : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %23 = "neura.data_mov"(%19) {mapping_locs = [{id = 35 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %24 = "neura.data_mov"(%10) {mapping_locs = [{id = 28 : i32, resource = "link", time_step = 1 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %25 = "neura.add"(%23, %24) {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 2 : i32, x = 2 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %26 = "neura.data_mov"(%25) {mapping_locs = [{id = 40 : i32, resource = "register", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %27 = "neura.data_mov"(%7) {mapping_locs = [{id = 28 : i32, resource = "link", time_step = 2 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %28 = "neura.icmp"(%26, %27) <{cmpType = "slt"}> {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 3 : i32, x = 2 : i32, y = 2 : i32}]} : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %29 = "neura.data_mov"(%25) {mapping_locs = [{id = 32 : i32, resource = "link", time_step = 2 : i32}, {id = 44 : i32, resource = "register", time_step = 3 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %30 = "neura.data_mov"(%28) {mapping_locs = [{id = 32 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %31 = neura.grant_predicate %29, %30 {mapping_locs = [{id = 11 : i32, resource = "tile", time_step = 4 : i32, x = 3 : i32, y = 2 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// MAPPING-NEXT:     neura.ctrl_mov %31 -> %17 {mapping_locs = [{id = 45 : i32, resource = "register", time_step = 4 : i32}, {id = 45 : i32, resource = "register", time_step = 5 : i32}]} : !neura.data<i64, i1> !neura.data<i64, i1>
+// MAPPING-NEXT:     %32 = "neura.data_mov"(%22) {mapping_locs = [{id = 30 : i32, resource = "link", time_step = 4 : i32}, {id = 52 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %33 = "neura.data_mov"(%28) {mapping_locs = [{id = 34 : i32, resource = "link", time_step = 3 : i32}, {id = 43 : i32, resource = "link", time_step = 4 : i32}, {id = 53 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %34 = neura.grant_predicate %32, %33 {mapping_locs = [{id = 13 : i32, resource = "tile", time_step = 6 : i32, x = 1 : i32, y = 3 : i32}]} : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// MAPPING-NEXT:     neura.ctrl_mov %34 -> %14 {mapping_locs = [{id = 40 : i32, resource = "link", time_step = 6 : i32}, {id = 39 : i32, resource = "link", time_step = 7 : i32}]} : !neura.data<f32, i1> !neura.data<f32, i1>
+// MAPPING-NEXT:     %35 = "neura.data_mov"(%13) {mapping_locs = [{id = 20 : i32, resource = "register", time_step = 3 : i32}, {id = 20 : i32, resource = "register", time_step = 4 : i32}, {id = 20 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %36 = "neura.data_mov"(%28) {mapping_locs = [{id = 31 : i32, resource = "link", time_step = 3 : i32}, {id = 29 : i32, resource = "link", time_step = 4 : i32}, {id = 21 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %37 = neura.grant_predicate %35, %36 {mapping_locs = [{id = 5 : i32, resource = "tile", time_step = 6 : i32, x = 1 : i32, y = 1 : i32}]} : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// MAPPING-NEXT:     neura.ctrl_mov %37 -> %11 {mapping_locs = [{id = 20 : i32, resource = "register", time_step = 6 : i32}, {id = 20 : i32, resource = "register", time_step = 7 : i32}]} : !neura.data<f32, i1> !neura.data<f32, i1>
+// MAPPING-NEXT:     %38 = "neura.data_mov"(%10) {mapping_locs = [{id = 29 : i32, resource = "link", time_step = 1 : i32}, {id = 14 : i32, resource = "link", time_step = 2 : i32}, {id = 24 : i32, resource = "register", time_step = 3 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %39 = "neura.data_mov"(%28) {mapping_locs = [{id = 33 : i32, resource = "link", time_step = 3 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %40 = neura.grant_predicate %38, %39 {mapping_locs = [{id = 6 : i32, resource = "tile", time_step = 4 : i32, x = 2 : i32, y = 1 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// MAPPING-NEXT:     neura.ctrl_mov %40 -> %8 {mapping_locs = [{id = 17 : i32, resource = "link", time_step = 4 : i32}, {id = 16 : i32, resource = "link", time_step = 5 : i32}]} : !neura.data<i64, i1> !neura.data<i64, i1>
+// MAPPING-NEXT:     %41 = "neura.data_mov"(%7) {mapping_locs = [{id = 29 : i32, resource = "link", time_step = 2 : i32}, {id = 14 : i32, resource = "link", time_step = 3 : i32}, {id = 20 : i32, resource = "link", time_step = 4 : i32}]} : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// MAPPING-NEXT:     %42 = "neura.data_mov"(%28) {mapping_locs = [{id = 41 : i32, resource = "register", time_step = 3 : i32}, {id = 41 : i32, resource = "register", time_step = 4 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %43 = neura.grant_predicate %41, %42 {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 5 : i32, x = 2 : i32, y = 2 : i32}]} : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// MAPPING-NEXT:     neura.ctrl_mov %43 -> %5 {mapping_locs = [{id = 31 : i32, resource = "link", time_step = 5 : i32}, {id = 36 : i32, resource = "register", time_step = 6 : i32}]} : !neura.data<i64, i1> !neura.data<i64, i1>
+// MAPPING-NEXT:     %44 = "neura.data_mov"(%28) {mapping_locs = [{id = 40 : i32, resource = "register", time_step = 3 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %45 = "neura.not"(%44) {mapping_locs = [{id = 10 : i32, resource = "tile", time_step = 4 : i32, x = 2 : i32, y = 2 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %46 = "neura.data_mov"(%22) {mapping_locs = [{id = 28 : i32, resource = "link", time_step = 4 : i32}, {id = 34 : i32, resource = "link", time_step = 5 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %47 = "neura.data_mov"(%45) {mapping_locs = [{id = 34 : i32, resource = "link", time_step = 4 : i32}, {id = 56 : i32, resource = "register", time_step = 5 : i32}]} : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// MAPPING-NEXT:     %48 = neura.grant_predicate %46, %47 {mapping_locs = [{id = 14 : i32, resource = "tile", time_step = 6 : i32, x = 2 : i32, y = 3 : i32}]} : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// MAPPING-NEXT:     %49 = "neura.data_mov"(%48) {mapping_locs = [{id = 43 : i32, resource = "link", time_step = 6 : i32}]} : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// MAPPING-NEXT:     "neura.return"(%49) {mapping_locs = [{id = 13 : i32, resource = "tile", time_step = 7 : i32, x = 1 : i32, y = 3 : i32}]} : (!neura.data<f32, i1>) -> ()
 // MAPPING-NEXT:   }
 
 // INST:        "name": "neura.fadd",

--- a/test/neura/ctrl/for_with_if.mlir
+++ b/test/neura/ctrl/for_with_if.mlir
@@ -1,0 +1,184 @@
+// RUN: mlir-opt %s \
+// RUN: --lower-affine \
+// RUN: --convert-scf-to-cf \
+// RUN: --convert-cf-to-llvm -o %t-llvm.mlir
+
+// RUN: mlir-neura-opt %t-llvm.mlir \
+// RUN: --assign-accelerator \
+// RUN: --lower-arith-to-neura \
+// RUN: --lower-memref-to-neura \
+// RUN: --lower-builtin-to-neura \
+// RUN: --lower-llvm-to-neura \
+// RUN: | FileCheck %s
+
+// RUN: mlir-neura-opt %t-llvm.mlir \
+// RUN: --assign-accelerator \
+// RUN: --lower-arith-to-neura \
+// RUN: --lower-memref-to-neura \
+// RUN: --lower-builtin-to-neura \
+// RUN: --lower-llvm-to-neura \
+// RUN: --canonicalize-cast \
+// RUN: --canonicalize-live-in \
+// RUN: --leverage-predicated-value \
+// RUN: --transform-ctrl-to-data-flow | FileCheck %s -check-prefix=CTRL2DATA
+
+module attributes {} {
+  func.func @_Z11for_with_ifPi(%arg0: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
+    %c128 = arith.constant 128 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c-5_i32 = arith.constant -5 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c1000_i32 = arith.constant 1000 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %0 = scf.for %arg1 = %c0 to %c128 step %c1 iter_args(%arg2 = %c0_i32) -> (i32) {
+      %1 = arith.cmpi sge, %arg2, %c1000_i32 : i32
+      %2 = scf.if %1 -> (i32) {
+        %7 = arith.addi %arg2, %c-5_i32 : i32
+        scf.yield %7 : i32
+      } else {
+        scf.yield %arg2 : i32
+      }
+      %3 = memref.load %arg0[%arg1] : memref<?xi32>
+      %4 = arith.muli %3, %c2_i32 : i32
+      %5 = arith.addi %4, %c1_i32 : i32
+      %6 = arith.addi %2, %5 : i32
+      scf.yield %6 : i32
+    }
+    return %0 : i32
+  }
+}
+
+// CHECK:        func.func @_Z11for_with_ifPi(%arg0: memref<?xi32>) -> i32 attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:     %0 = "neura.constant"() <{predicate = true, value = 0 : i32}> : () -> i32
+// CHECK-NEXT:     %1 = "neura.constant"() <{predicate = true, value = 1000 : i32}> : () -> i32
+// CHECK-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 2 : i32}> : () -> i32
+// CHECK-NEXT:     %3 = "neura.constant"() <{predicate = true, value = 1 : i32}> : () -> i32
+// CHECK-NEXT:     %4 = "neura.constant"() <{predicate = true, value = -5 : i32}> : () -> i32
+// CHECK-NEXT:     %5 = "neura.constant"() <{predicate = true, value = 1 : index}> : () -> index
+// CHECK-NEXT:     %6 = "neura.constant"() <{predicate = true, value = 128 : index}> : () -> index
+// CHECK-NEXT:     %7 = "neura.constant"() <{predicate = true, value = 0 : index}> : () -> index
+// CHECK-NEXT:     %8 = "neura.cast"(%7) <{cast_type = "index_to_int"}> : (index) -> i64
+// CHECK-NEXT:     neura.br %8, %0 : i64, i32 to ^bb1
+// CHECK-NEXT:   ^bb1(%9: i64, %10: i32):  // 2 preds: ^bb0, ^bb6
+// CHECK-NEXT:     %11 = "neura.cast"(%9) <{cast_type = "int_to_index"}> : (i64) -> index
+// CHECK-NEXT:     %12 = "neura.icmp"(%11, %6) <{cmpType = "slt"}> : (index, index) -> i1
+// CHECK-NEXT:     neura.cond_br %12 : i1 then to ^bb2 else to ^bb7
+// CHECK-NEXT:   ^bb2:  // pred: ^bb1
+// CHECK-NEXT:     %13 = "neura.icmp"(%10, %1) <{cmpType = "sge"}> : (i32, i32) -> i1
+// CHECK-NEXT:     neura.cond_br %13 : i1 then to ^bb3 else to ^bb4
+// CHECK-NEXT:   ^bb3:  // pred: ^bb2
+// CHECK-NEXT:     %14 = "neura.add"(%10, %4) : (i32, i32) -> i32
+// CHECK-NEXT:     neura.br %14 : i32 to ^bb5
+// CHECK-NEXT:   ^bb4:  // pred: ^bb2
+// CHECK-NEXT:     neura.br %10 : i32 to ^bb5
+// CHECK-NEXT:   ^bb5(%15: i32):  // 2 preds: ^bb3, ^bb4
+// CHECK-NEXT:     neura.br to ^bb6
+// CHECK-NEXT:   ^bb6:  // pred: ^bb5
+// CHECK-NEXT:     %16 = neura.load_indexed %arg0[%11 : index] memref<?xi32> : i32
+// CHECK-NEXT:     %17 = "neura.mul"(%16, %2) : (i32, i32) -> i32
+// CHECK-NEXT:     %18 = "neura.add"(%17, %3) : (i32, i32) -> i32
+// CHECK-NEXT:     %19 = "neura.add"(%15, %18) : (i32, i32) -> i32
+// CHECK-NEXT:     %20 = "neura.add"(%11, %5) : (index, index) -> index
+// CHECK-NEXT:     %21 = "neura.cast"(%20) <{cast_type = "index_to_int"}> : (index) -> i64
+// CHECK-NEXT:     neura.br %21, %19 : i64, i32 to ^bb1
+// CHECK-NEXT:   ^bb7:  // pred: ^bb1
+// CHECK-NEXT:     "neura.return"(%10) : (i32) -> ()
+// CHECK-NEXT:   }
+
+// CTRL2DATA:        func.func @_Z11for_with_ifPi(%arg0: memref<?xi32>) -> i32 attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
+// CTRL2DATA-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<memref<?xi32>, i1>
+// CTRL2DATA-NEXT:     %1 = "neura.grant_once"(%0) : (!neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
+// CTRL2DATA-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 0 : i32}> : () -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %3 = "neura.grant_once"(%2) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %4 = "neura.constant"() <{predicate = true, value = 1000 : i32}> : () -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %5 = "neura.grant_once"(%4) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %6 = "neura.constant"() <{predicate = true, value = 2 : i32}> : () -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %7 = "neura.grant_once"(%6) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %8 = "neura.constant"() <{predicate = true, value = 1 : i32}> : () -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %9 = "neura.grant_once"(%8) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %10 = "neura.constant"() <{predicate = true, value = -5 : i32}> : () -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %11 = "neura.grant_once"(%10) : (!neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %12 = "neura.constant"() <{predicate = true, value = 1 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %13 = "neura.grant_once"(%12) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %14 = "neura.constant"() <{predicate = true, value = 128 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %15 = "neura.grant_once"(%14) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %16 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %17 = "neura.grant_once"(%16) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %18 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %19 = "neura.phi"(%18, %13) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %20 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %21 = "neura.phi"(%20, %9) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %22 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %23 = "neura.phi"(%22, %7) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %24 = neura.reserve : !neura.data<memref<?xi32>, i1>
+// CTRL2DATA-NEXT:     %25 = "neura.phi"(%24, %1) : (!neura.data<memref<?xi32>, i1>, !neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
+// CTRL2DATA-NEXT:     %26 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %27 = "neura.phi"(%26, %11) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %28 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %29 = "neura.phi"(%28, %5) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %30 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %31 = "neura.phi"(%30, %15) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %32 = neura.reserve : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %33 = "neura.phi"(%32, %3) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %34 = neura.reserve : !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %35 = "neura.phi"(%34, %17) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %36 = "neura.icmp"(%35, %31) <{cmpType = "slt"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %37 = neura.grant_predicate %33, %36 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %38 = neura.grant_predicate %29, %36 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %39 = neura.grant_predicate %27, %36 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %40 = neura.grant_predicate %25, %36 : !neura.data<memref<?xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?xi32>, i1>
+// CTRL2DATA-NEXT:     %41 = neura.grant_predicate %35, %36 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %42 = neura.grant_predicate %23, %36 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %43 = neura.grant_predicate %21, %36 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %44 = neura.grant_predicate %19, %36 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %45 = neura.grant_predicate %31, %36 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %46 = "neura.not"(%36) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %47 = neura.grant_predicate %33, %46 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %48 = "neura.icmp"(%37, %38) <{cmpType = "sge"}> : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %49 = neura.grant_predicate %37, %48 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %50 = neura.grant_predicate %39, %48 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %51 = neura.grant_predicate %40, %48 : !neura.data<memref<?xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?xi32>, i1>
+// CTRL2DATA-NEXT:     %52 = neura.grant_predicate %41, %48 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %53 = neura.grant_predicate %42, %48 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %54 = neura.grant_predicate %43, %48 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %55 = neura.grant_predicate %44, %48 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %56 = neura.grant_predicate %45, %48 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %57 = neura.grant_predicate %38, %48 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %58 = "neura.not"(%48) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %59 = neura.grant_predicate %37, %58 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %60 = neura.grant_predicate %40, %58 : !neura.data<memref<?xi32>, i1>, !neura.data<i1, i1> -> !neura.data<memref<?xi32>, i1>
+// CTRL2DATA-NEXT:     %61 = neura.grant_predicate %41, %58 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %62 = neura.grant_predicate %42, %58 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %63 = neura.grant_predicate %43, %58 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %64 = neura.grant_predicate %44, %58 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %65 = neura.grant_predicate %45, %58 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %66 = neura.grant_predicate %38, %58 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %67 = neura.grant_predicate %39, %58 : !neura.data<i32, i1>, !neura.data<i1, i1> -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %68 = "neura.add"(%49, %50) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %69 = "neura.phi"(%50, %67) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %70 = "neura.phi"(%57, %66) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %71 = "neura.phi"(%56, %65) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %72 = "neura.phi"(%55, %64) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %73 = "neura.phi"(%54, %63) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %74 = "neura.phi"(%53, %62) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %75 = "neura.phi"(%52, %61) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     %76 = "neura.phi"(%51, %60) : (!neura.data<memref<?xi32>, i1>, !neura.data<memref<?xi32>, i1>) -> !neura.data<memref<?xi32>, i1>
+// CTRL2DATA-NEXT:     %77 = "neura.phi"(%68, %59) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %78 = neura.load_indexed %76[%75 : !neura.data<i64, i1>] !neura.data<memref<?xi32>, i1> : !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %79 = "neura.mul"(%78, %74) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %80 = "neura.add"(%79, %73) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %81 = "neura.add"(%77, %80) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     %82 = "neura.add"(%75, %72) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %82 -> %34 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %81 -> %32 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %71 -> %30 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %70 -> %28 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %69 -> %26 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %76 -> %24 : !neura.data<memref<?xi32>, i1> !neura.data<memref<?xi32>, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %74 -> %22 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %73 -> %20 : !neura.data<i32, i1> !neura.data<i32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %72 -> %18 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CTRL2DATA-NEXT:     "neura.return"(%47) : (!neura.data<i32, i1>) -> ()
+// CTRL2DATA-NEXT:   }

--- a/test/neura/ctrl/nested_branch.mlir
+++ b/test/neura/ctrl/nested_branch.mlir
@@ -38,29 +38,29 @@ func.func @complex_test(%in: i64) -> f32 {
   return %v : f32
 }
 
-// CHECK:      func.func @complex_test(%arg0: i64) -> f32 attributes {accelerator = "neura"} {
-// CHECK-NEXT:   %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<i64, i1>
-// CHECK-NEXT:   %1 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
-// CHECK-NEXT:   %2 = "neura.constant"() <{predicate = true, value = 1.000000e+00 : f32}> : () -> !neura.data<f32, i1>
-// CHECK-NEXT:   %3 = "neura.constant"() <{predicate = true, value = 2.000000e+00 : f32}> : () -> !neura.data<f32, i1>
-// CHECK-NEXT:   %4 = "neura.constant"() <{predicate = true, value = 3.000000e+00 : f32}> : () -> !neura.data<f32, i1>
-// CHECK-NEXT:   %5 = "neura.constant"() <{predicate = true, value = 4.000000e+00 : f32}> : () -> !neura.data<f32, i1>
-// CHECK-NEXT:   %6 = "neura.icmp"(%0, %1) <{cmpType = "eq"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CHECK-NEXT:   neura.cond_br %6 : !neura.data<i1, i1> then %4, %5 : !neura.data<f32, i1>, !neura.data<f32, i1> to ^bb3 else %2, %3 : !neura.data<f32, i1>, !neura.data<f32, i1> to ^bb1
-// CHECK-NEXT: ^bb1(%7: !neura.data<f32, i1>, %8: !neura.data<f32, i1>):  // 2 preds: ^bb0, ^bb2
-// CHECK-NEXT:   %9 = "neura.fcmp"(%7, %8) <{cmpType = "olt"}> : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<i1, i1>
-// CHECK-NEXT:   neura.cond_br %9 : !neura.data<i1, i1> then %7, %2, %3 : !neura.data<f32, i1>, !neura.data<f32, i1>, !neura.data<f32, i1> to ^bb2 else %7 : !neura.data<f32, i1> to ^bb4
-// CHECK-NEXT: ^bb2(%10: !neura.data<f32, i1>, %11: !neura.data<f32, i1>, %12: !neura.data<f32, i1>):  // pred: ^bb1
-// CHECK-NEXT:   %13 = "neura.fadd"(%10, %11) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-NEXT:   neura.br %13, %12 : !neura.data<f32, i1>, !neura.data<f32, i1> to ^bb1
-// CHECK-NEXT: ^bb3(%14: !neura.data<f32, i1>, %15: !neura.data<f32, i1>):  // pred: ^bb0
-// CHECK-NEXT:   %16 = "neura.fmul"(%14, %15) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-NEXT:   neura.br %16 : !neura.data<f32, i1> to ^bb4
-// CHECK-NEXT: ^bb4(%17: !neura.data<f32, i1>):  // 2 preds: ^bb1, ^bb3
-// CHECK-NEXT:   "neura.return"(%17) : (!neura.data<f32, i1>) -> ()
-// CHECK-NEXT: }
+// CHECK:       func.func @complex_test(%arg0: i64) -> f32 attributes {accelerator = "neura"} {
+// CHECK-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<i64, i1>
+// CHECK-NEXT:     %1 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
+// CHECK-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 1.000000e+00 : f32}> : () -> !neura.data<f32, i1>
+// CHECK-NEXT:     %3 = "neura.constant"() <{predicate = true, value = 2.000000e+00 : f32}> : () -> !neura.data<f32, i1>
+// CHECK-NEXT:     %4 = "neura.constant"() <{predicate = true, value = 3.000000e+00 : f32}> : () -> !neura.data<f32, i1>
+// CHECK-NEXT:     %5 = "neura.constant"() <{predicate = true, value = 4.000000e+00 : f32}> : () -> !neura.data<f32, i1>
+// CHECK-NEXT:     %6 = "neura.icmp"(%0, %1) <{cmpType = "eq"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CHECK-NEXT:     neura.cond_br %6 : !neura.data<i1, i1> then %4, %5 : !neura.data<f32, i1>, !neura.data<f32, i1> to ^bb3 else %2, %3, %2 : !neura.data<f32, i1>, !neura.data<f32, i1>, !neura.data<f32, i1> to ^bb1
+// CHECK-NEXT:   ^bb1(%7: !neura.data<f32, i1>, %8: !neura.data<f32, i1>, %9: !neura.data<f32, i1>):  // 2 preds: ^bb0, ^bb2
+// CHECK-NEXT:     %10 = "neura.fcmp"(%7, %8) <{cmpType = "olt"}> : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<i1, i1>
+// CHECK-NEXT:     neura.cond_br %10 : !neura.data<i1, i1> then %7, %9, %8 : !neura.data<f32, i1>, !neura.data<f32, i1>, !neura.data<f32, i1> to ^bb2 else %7 : !neura.data<f32, i1> to ^bb4
+// CHECK-NEXT:   ^bb2(%11: !neura.data<f32, i1>, %12: !neura.data<f32, i1>, %13: !neura.data<f32, i1>):  // pred: ^bb1
+// CHECK-NEXT:     %14 = "neura.fadd"(%11, %12) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-NEXT:     neura.br %14, %13, %12 : !neura.data<f32, i1>, !neura.data<f32, i1>, !neura.data<f32, i1> to ^bb1
+// CHECK-NEXT:   ^bb3(%15: !neura.data<f32, i1>, %16: !neura.data<f32, i1>):  // pred: ^bb0
+// CHECK-NEXT:     %17 = "neura.fmul"(%15, %16) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-NEXT:     neura.br %17 : !neura.data<f32, i1> to ^bb4
+// CHECK-NEXT:   ^bb4(%18: !neura.data<f32, i1>):  // 2 preds: ^bb1, ^bb3
+// CHECK-NEXT:     "neura.return"(%18) : (!neura.data<f32, i1>) -> ()
+// CHECK-NEXT:   }
 
-// CTRL2DATA:     func.func @complex_test(%arg0: i64) -> f32 attributes {accelerator = "neura"} {
+// CTRL2DATA:        func.func @complex_test(%arg0: i64) -> f32 attributes {accelerator = "neura"} {
 // CTRL2DATA-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %1 = "neura.constant"() <{predicate = true, value = 0 : i64}> : () -> !neura.data<i64, i1>
 // CTRL2DATA-NEXT:     %2 = "neura.constant"() <{predicate = true, value = 1.000000e+00 : f32}> : () -> !neura.data<f32, i1>
@@ -78,20 +78,24 @@ func.func @complex_test(%in: i64) -> f32 {
 // CTRL2DATA-NEXT:     %14 = "neura.not"(%11) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
 // CTRL2DATA-NEXT:     %15 = neura.grant_predicate %3, %14 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
 // CTRL2DATA-NEXT:     %16 = neura.grant_predicate %5, %14 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %17 = neura.reserve : !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %18 = "neura.phi"(%17, %16) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %19 = neura.reserve : !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %20 = "neura.phi"(%19, %15) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %21 = "neura.fcmp"(%20, %18) <{cmpType = "olt"}> : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %22 = neura.grant_predicate %20, %21 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %23 = neura.grant_predicate %3, %21 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %24 = neura.grant_predicate %5, %21 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %25 = "neura.not"(%21) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %20, %25 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %27 = "neura.fadd"(%22, %23) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %27 -> %19 : !neura.data<f32, i1> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     neura.ctrl_mov %24 -> %17 : !neura.data<f32, i1> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %28 = "neura.fmul"(%12, %13) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     %29 = "neura.phi"(%26, %28) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CTRL2DATA-NEXT:     "neura.return"(%29) : (!neura.data<f32, i1>) -> ()
+// CTRL2DATA-NEXT:     %17 = neura.grant_predicate %3, %14 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %18 = neura.reserve : !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %19 = "neura.phi"(%18, %17) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %20 = neura.reserve : !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %21 = "neura.phi"(%20, %16) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %22 = neura.reserve : !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %23 = "neura.phi"(%22, %15) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %24 = "neura.fcmp"(%23, %21) <{cmpType = "olt"}> : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %25 = neura.grant_predicate %23, %24 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %26 = neura.grant_predicate %19, %24 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %27 = neura.grant_predicate %21, %24 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %28 = "neura.not"(%24) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CTRL2DATA-NEXT:     %29 = neura.grant_predicate %23, %28 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %30 = "neura.fadd"(%25, %26) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %30 -> %22 : !neura.data<f32, i1> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %27 -> %20 : !neura.data<f32, i1> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     neura.ctrl_mov %26 -> %18 : !neura.data<f32, i1> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %31 = "neura.fmul"(%12, %13) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     %32 = "neura.phi"(%29, %31) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CTRL2DATA-NEXT:     "neura.return"(%32) : (!neura.data<f32, i1>) -> ()
 // CTRL2DATA-NEXT:   }

--- a/test/neura/for_loop/test.mlir
+++ b/test/neura/for_loop/test.mlir
@@ -32,7 +32,7 @@
 // RUN:   --insert-data-mov \
 // RUN:  | FileCheck %s --check-prefix=CHECK-MOV
 
-// CHECK: llvm.func local_unnamed_addr @_Z6kernelPfS_S_(%arg0: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}, %arg1: !llvm.ptr {llvm.nocapture, llvm.noundef}, %arg2: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}) attributes {accelerator = "neura", memory_effects = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = none>, no_unwind, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], target_cpu = "x86-64", target_features = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, tune_cpu = "generic"} {
+// CHECK:       llvm.func local_unnamed_addr @_Z6kernelPfS_S_(%arg0: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}, %arg1: !llvm.ptr {llvm.nocapture, llvm.noundef}, %arg2: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}) attributes {accelerator = "neura", memory_effects = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = none>, no_unwind, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], target_cpu = "x86-64", target_features = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, tune_cpu = "generic"} {
 // CHECK-NEXT:     %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> !neura.data<!llvm.ptr, i1>
 // CHECK-NEXT:     %1 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<!llvm.ptr, i1>
 // CHECK-NEXT:     %2 = "neura.constant"() <{predicate = true, value = "%arg2"}> : () -> !neura.data<!llvm.ptr, i1>
@@ -51,13 +51,13 @@
 // CHECK-NEXT:     "neura.store"(%19, %11) : (!neura.data<f32, i1>, !neura.data<!llvm.ptr, i1>) -> ()
 // CHECK-NEXT:     %20 = "neura.add"(%7, %12) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
 // CHECK-NEXT:     %21 = "neura.icmp"(%20, %13) <{cmpType = "eq"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CHECK-NEXT:     neura.cond_br %21 : !neura.data<i1, i1> then to ^bb2 else %20, %19, %0, %2, %1, %4, %5 : !neura.data<i64, i1>, !neura.data<f32, i1>, !neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>, !neura.data<i64, i1>, !neura.data<i64, i1> to ^bb1
+// CHECK-NEXT:     neura.cond_br %21 : !neura.data<i1, i1> then to ^bb2 else %20, %19, %9, %10, %11, %12, %13 : !neura.data<i64, i1>, !neura.data<f32, i1>, !neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>, !neura.data<i64, i1>, !neura.data<i64, i1> to ^bb1
 // CHECK-NEXT:   ^bb2:  // pred: ^bb1
 // CHECK-NEXT:     "neura.return"() : () -> ()
 // CHECK-NEXT:   }
 
 // Verifies the neura ops are generated. And fusion happens.
-// CHECK-FUSED:        llvm.func local_unnamed_addr @_Z6kernelPfS_S_(%arg0: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}, %arg1: !llvm.ptr {llvm.nocapture, llvm.noundef}, %arg2: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}) attributes {accelerator = "neura", memory_effects = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = none>, no_unwind, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], target_cpu = "x86-64", target_features = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, tune_cpu = "generic"} {
+// CHECK-FUSED:       llvm.func local_unnamed_addr @_Z6kernelPfS_S_(%arg0: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}, %arg1: !llvm.ptr {llvm.nocapture, llvm.noundef}, %arg2: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}) attributes {accelerator = "neura", memory_effects = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = none>, no_unwind, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], target_cpu = "x86-64", target_features = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, tune_cpu = "generic"} {
 // CHECK-FUSED-NEXT:     %0 = "neura.grant_once"() <{constant_value = "%arg0"}> : () -> !neura.data<!llvm.ptr, i1>
 // CHECK-FUSED-NEXT:     %1 = "neura.grant_once"() <{constant_value = "%arg1"}> : () -> !neura.data<!llvm.ptr, i1>
 // CHECK-FUSED-NEXT:     %2 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<!llvm.ptr, i1>
@@ -94,104 +94,104 @@
 // CHECK-FUSED-NEXT:     neura.ctrl_mov %31 -> %21 : !neura.data<i64, i1> !neura.data<i64, i1>
 // CHECK-FUSED-NEXT:     %32 = neura.grant_predicate %27, %30 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
 // CHECK-FUSED-NEXT:     neura.ctrl_mov %32 -> %19 : !neura.data<f32, i1> !neura.data<f32, i1>
-// CHECK-FUSED-NEXT:     %33 = neura.grant_predicate %0, %30 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %33 = neura.grant_predicate %18, %30 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
 // CHECK-FUSED-NEXT:     neura.ctrl_mov %33 -> %17 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %34 = neura.grant_predicate %3, %30 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %34 = neura.grant_predicate %16, %30 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
 // CHECK-FUSED-NEXT:     neura.ctrl_mov %34 -> %15 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %35 = neura.grant_predicate %1, %30 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
+// CHECK-FUSED-NEXT:     %35 = neura.grant_predicate %14, %30 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
 // CHECK-FUSED-NEXT:     neura.ctrl_mov %35 -> %13 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
-// CHECK-FUSED-NEXT:     %36 = neura.grant_predicate %5, %30 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     %36 = neura.grant_predicate %12, %30 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
 // CHECK-FUSED-NEXT:     neura.ctrl_mov %36 -> %11 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CHECK-FUSED-NEXT:     %37 = neura.grant_predicate %6, %30 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CHECK-FUSED-NEXT:     %37 = neura.grant_predicate %10, %30 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
 // CHECK-FUSED-NEXT:     neura.ctrl_mov %37 -> %9 : !neura.data<i64, i1> !neura.data<i64, i1>
 // CHECK-FUSED-NEXT:     "neura.return"() : () -> ()
 // CHECK-FUSED-NEXT:   }
 
-// CHECK-MOV:           llvm.func local_unnamed_addr @_Z6kernelPfS_S_(%arg0: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}, %arg1: !llvm.ptr {llvm.nocapture, llvm.noundef}, %arg2: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}) attributes {accelerator = "neura", memory_effects = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = none>, no_unwind, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], target_cpu = "x86-64", target_features = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, tune_cpu = "generic"} {
-// CHECK-MOV-NEXT:         %0 = "neura.grant_once"() <{constant_value = "%arg0"}> : () -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %1 = "neura.grant_once"() <{constant_value = "%arg1"}> : () -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %2 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %3 = "neura.grant_once"() <{constant_value = "%arg2"}> : () -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %4 = "neura.grant_once"() <{constant_value = 0 : i64}> : () -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %5 = "neura.grant_once"() <{constant_value = 1 : i64}> : () -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %6 = "neura.grant_once"() <{constant_value = 32 : i64}> : () -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %7 = "neura.data_mov"(%2) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %8 = "neura.load"(%7) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:         %9 = "neura.data_mov"(%8) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:         %10 = "neura.grant_once"(%9) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:         %11 = neura.reserve : !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %12 = "neura.data_mov"(%6) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %13 = "neura.phi"(%11, %12) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %14 = neura.reserve : !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %15 = "neura.data_mov"(%5) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %16 = "neura.phi"(%14, %15) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %17 = neura.reserve : !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %18 = "neura.data_mov"(%1) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %19 = "neura.phi"(%17, %18) : (!neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %20 = neura.reserve : !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %21 = "neura.data_mov"(%3) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %22 = "neura.phi"(%20, %21) : (!neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %23 = neura.reserve : !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %24 = "neura.data_mov"(%0) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %25 = "neura.phi"(%23, %24) : (!neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %26 = neura.reserve : !neura.data<f32, i1>
-// CHECK-MOV-NEXT:         %27 = "neura.data_mov"(%10) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:         %28 = "neura.phi"(%26, %27) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:         %29 = neura.reserve : !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %30 = "neura.data_mov"(%4) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %31 = "neura.phi"(%29, %30) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %32 = "neura.data_mov"(%25) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %33 = "neura.data_mov"(%31) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %34 = "neura.gep"(%32, %33) : (!neura.data<!llvm.ptr, i1>, !neura.data<i64, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %35 = "neura.data_mov"(%34) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %36 = "neura.load"(%35) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:         %37 = "neura.data_mov"(%22) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %38 = "neura.data_mov"(%31) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %39 = "neura.gep"(%37, %38) : (!neura.data<!llvm.ptr, i1>, !neura.data<i64, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %40 = "neura.data_mov"(%39) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %41 = "neura.load"(%40) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:         %42 = "neura.data_mov"(%36) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:         %43 = "neura.data_mov"(%41) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:         %44 = "neura.data_mov"(%28) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:         %45 = "neura.fmul_fadd"(%42, %43, %44) : (!neura.data<f32, i1>, !neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:         %46 = "neura.data_mov"(%45) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:         %47 = "neura.data_mov"(%19) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         "neura.store"(%46, %47) : (!neura.data<f32, i1>, !neura.data<!llvm.ptr, i1>) -> ()
-// CHECK-MOV-NEXT:         %48 = "neura.data_mov"(%31) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %49 = "neura.data_mov"(%16) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %50 = "neura.add"(%48, %49) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %51 = "neura.data_mov"(%50) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %52 = "neura.data_mov"(%13) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %53 = "neura.icmp"(%51, %52) <{cmpType = "eq"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:         %54 = "neura.data_mov"(%53) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:         %55 = "neura.not"(%54) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:         %56 = "neura.data_mov"(%50) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %57 = "neura.data_mov"(%55) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:         %58 = neura.grant_predicate %56, %57 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         neura.ctrl_mov %58 -> %29 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %59 = "neura.data_mov"(%45) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:         %60 = "neura.data_mov"(%55) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:         %61 = neura.grant_predicate %59, %60 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:         neura.ctrl_mov %61 -> %26 : !neura.data<f32, i1> !neura.data<f32, i1>
-// CHECK-MOV-NEXT:         %62 = "neura.data_mov"(%0) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %63 = "neura.data_mov"(%55) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:         %64 = neura.grant_predicate %62, %63 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         neura.ctrl_mov %64 -> %23 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %65 = "neura.data_mov"(%3) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %66 = "neura.data_mov"(%55) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:         %67 = neura.grant_predicate %65, %66 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         neura.ctrl_mov %67 -> %20 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %68 = "neura.data_mov"(%1) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %69 = "neura.data_mov"(%55) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:         %70 = neura.grant_predicate %68, %69 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         neura.ctrl_mov %70 -> %17 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
-// CHECK-MOV-NEXT:         %71 = "neura.data_mov"(%5) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %72 = "neura.data_mov"(%55) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:         %73 = neura.grant_predicate %71, %72 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         neura.ctrl_mov %73 -> %14 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %74 = "neura.data_mov"(%6) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         %75 = "neura.data_mov"(%55) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
-// CHECK-MOV-NEXT:         %76 = neura.grant_predicate %74, %75 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         neura.ctrl_mov %76 -> %11 : !neura.data<i64, i1> !neura.data<i64, i1>
-// CHECK-MOV-NEXT:         "neura.return"() : () -> ()
-// CHECK-MOV-NEXT:       }
+// CHECK-MOV:        llvm.func local_unnamed_addr @_Z6kernelPfS_S_(%arg0: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}, %arg1: !llvm.ptr {llvm.nocapture, llvm.noundef}, %arg2: !llvm.ptr {llvm.nocapture, llvm.noundef, llvm.readonly}) attributes {accelerator = "neura", memory_effects = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = none>, no_unwind, passthrough = ["mustprogress", "nofree", "norecurse", "nosync", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], target_cpu = "x86-64", target_features = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, tune_cpu = "generic"} {
+// CHECK-MOV-NEXT:     %0 = "neura.grant_once"() <{constant_value = "%arg0"}> : () -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %1 = "neura.grant_once"() <{constant_value = "%arg1"}> : () -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %2 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %3 = "neura.grant_once"() <{constant_value = "%arg2"}> : () -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %4 = "neura.grant_once"() <{constant_value = 0 : i64}> : () -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %5 = "neura.grant_once"() <{constant_value = 1 : i64}> : () -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %6 = "neura.grant_once"() <{constant_value = 32 : i64}> : () -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %7 = "neura.data_mov"(%2) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %8 = "neura.load"(%7) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:     %9 = "neura.data_mov"(%8) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:     %10 = "neura.grant_once"(%9) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:     %11 = neura.reserve : !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %12 = "neura.data_mov"(%6) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %13 = "neura.phi"(%11, %12) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %14 = neura.reserve : !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %15 = "neura.data_mov"(%5) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %16 = "neura.phi"(%14, %15) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %17 = neura.reserve : !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %18 = "neura.data_mov"(%1) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %19 = "neura.phi"(%17, %18) : (!neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %20 = neura.reserve : !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %21 = "neura.data_mov"(%3) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %22 = "neura.phi"(%20, %21) : (!neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %23 = neura.reserve : !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %24 = "neura.data_mov"(%0) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %25 = "neura.phi"(%23, %24) : (!neura.data<!llvm.ptr, i1>, !neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %26 = neura.reserve : !neura.data<f32, i1>
+// CHECK-MOV-NEXT:     %27 = "neura.data_mov"(%10) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:     %28 = "neura.phi"(%26, %27) : (!neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:     %29 = neura.reserve : !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %30 = "neura.data_mov"(%4) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %31 = "neura.phi"(%29, %30) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %32 = "neura.data_mov"(%25) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %33 = "neura.data_mov"(%31) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %34 = "neura.gep"(%32, %33) : (!neura.data<!llvm.ptr, i1>, !neura.data<i64, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %35 = "neura.data_mov"(%34) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %36 = "neura.load"(%35) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:     %37 = "neura.data_mov"(%22) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %38 = "neura.data_mov"(%31) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %39 = "neura.gep"(%37, %38) : (!neura.data<!llvm.ptr, i1>, !neura.data<i64, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %40 = "neura.data_mov"(%39) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %41 = "neura.load"(%40) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:     %42 = "neura.data_mov"(%36) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:     %43 = "neura.data_mov"(%41) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:     %44 = "neura.data_mov"(%28) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:     %45 = "neura.fmul_fadd"(%42, %43, %44) : (!neura.data<f32, i1>, !neura.data<f32, i1>, !neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:     %46 = "neura.data_mov"(%45) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:     %47 = "neura.data_mov"(%19) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     "neura.store"(%46, %47) : (!neura.data<f32, i1>, !neura.data<!llvm.ptr, i1>) -> ()
+// CHECK-MOV-NEXT:     %48 = "neura.data_mov"(%31) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %49 = "neura.data_mov"(%16) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %50 = "neura.add"(%48, %49) : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %51 = "neura.data_mov"(%50) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %52 = "neura.data_mov"(%13) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %53 = "neura.icmp"(%51, %52) <{cmpType = "eq"}> : (!neura.data<i64, i1>, !neura.data<i64, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:     %54 = "neura.data_mov"(%53) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:     %55 = "neura.not"(%54) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:     %56 = "neura.data_mov"(%50) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %57 = "neura.data_mov"(%55) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:     %58 = neura.grant_predicate %56, %57 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     neura.ctrl_mov %58 -> %29 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %59 = "neura.data_mov"(%45) : (!neura.data<f32, i1>) -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:     %60 = "neura.data_mov"(%55) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:     %61 = neura.grant_predicate %59, %60 : !neura.data<f32, i1>, !neura.data<i1, i1> -> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:     neura.ctrl_mov %61 -> %26 : !neura.data<f32, i1> !neura.data<f32, i1>
+// CHECK-MOV-NEXT:     %62 = "neura.data_mov"(%25) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %63 = "neura.data_mov"(%55) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:     %64 = neura.grant_predicate %62, %63 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     neura.ctrl_mov %64 -> %23 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %65 = "neura.data_mov"(%22) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %66 = "neura.data_mov"(%55) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:     %67 = neura.grant_predicate %65, %66 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     neura.ctrl_mov %67 -> %20 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %68 = "neura.data_mov"(%19) : (!neura.data<!llvm.ptr, i1>) -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %69 = "neura.data_mov"(%55) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:     %70 = neura.grant_predicate %68, %69 : !neura.data<!llvm.ptr, i1>, !neura.data<i1, i1> -> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     neura.ctrl_mov %70 -> %17 : !neura.data<!llvm.ptr, i1> !neura.data<!llvm.ptr, i1>
+// CHECK-MOV-NEXT:     %71 = "neura.data_mov"(%16) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %72 = "neura.data_mov"(%55) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:     %73 = neura.grant_predicate %71, %72 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     neura.ctrl_mov %73 -> %14 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %74 = "neura.data_mov"(%13) : (!neura.data<i64, i1>) -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     %75 = "neura.data_mov"(%55) : (!neura.data<i1, i1>) -> !neura.data<i1, i1>
+// CHECK-MOV-NEXT:     %76 = neura.grant_predicate %74, %75 : !neura.data<i64, i1>, !neura.data<i1, i1> -> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     neura.ctrl_mov %76 -> %11 : !neura.data<i64, i1> !neura.data<i64, i1>
+// CHECK-MOV-NEXT:     "neura.return"() : () -> ()
+// CHECK-MOV-NEXT:   }


### PR DESCRIPTION
In previous `--canonicalize-live-in` pass, we traverse the blocks in topological order. But for case like:
```
module {
  func.func @_Z10bert_node1PA1_A1_A1_A1_A128_bPA1_A128_S1_(%arg0: memref<?x1x1x1x1x128xi8>, %arg1: memref<?x1x128x1x1x128xi8>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
    %0 = "neura.constant"() <{value = 1 : index}> : () -> index
    %1 = "neura.constant"() <{value = 128 : index}> : () -> index
    %2 = "neura.constant"() <{value = 0 : index}> : () -> index
    %3 = "neura.cast"(%2) <{cast_type = "index_to_int"}> : (index) -> i64
    neura.br %3 : i64 to ^bb1
  ^bb1(%4: i64):  // 2 preds: ^bb0, ^bb5
    %5 = "neura.cast"(%4) <{cast_type = "int_to_index"}> : (i64) -> index
    %6 = "neura.icmp"(%5, %1) <{cmpType = "slt"}> : (index, index) -> i1
    neura.cond_br %6 : i1 then to ^bb2 else to ^bb6
  ^bb2:  // pred: ^bb1
    %7 = "neura.cast"(%2) <{cast_type = "index_to_int"}> : (index) -> i64
    neura.br %7 : i64 to ^bb3
  ^bb3(%8: i64):  // 2 preds: ^bb2, ^bb4
    %9 = "neura.cast"(%8) <{cast_type = "int_to_index"}> : (i64) -> index
    %10 = "neura.icmp"(%9, %1) <{cmpType = "slt"}> : (index, index) -> i1
    neura.cond_br %10 : i1 then to ^bb4 else to ^bb5
  ^bb4:  // pred: ^bb3
    %11 = neura.load_indexed %arg0[%2, %2, %2, %2, %2, %9 : index, index, index, index, index, index] memref<?x1x1x1x1x128xi8> : i8
    neura.store_indexed %11 to %arg1[%2, %2, %5, %2, %2, %9 : index, index, index, index, index, index] memref<?x1x128x1x1x128xi8> : i8
    %12 = "neura.add"(%9, %0) : (index, index) -> index
    %13 = "neura.cast"(%12) <{cast_type = "index_to_int"}> : (index) -> i64
    neura.br %13 : i64 to ^bb3
  ^bb5:  // pred: ^bb3
    %14 = "neura.add"(%5, %0) : (index, index) -> index
    %15 = "neura.cast"(%14) <{cast_type = "index_to_int"}> : (index) -> i64
    neura.br %15 : i64 to ^bb1
  ^bb6:  // pred: ^bb1
    "neura.return"() : () -> ()
  }
}
```

When we identify the `%2` in `bb2` as a live-in and wrap it in the block arguments of `bb2` and update corresponding operands of `neura.cond_br` in `bb1`. Now `%2` is also in `neura.cond_br` and thus a live-in for `bb1`. But current implementation fails to update the block arguments of `bb1`.

Thus current implementation results in:
```
  func.func @_Z10bert_node1PA1_A1_A1_A1_A128_bPA1_A128_S1_(%arg0: memref<?x1x1x1x1x128xi8>, %arg1: memref<?x1x128x1x1x128xi8>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
    %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> memref<?x1x1x1x1x128xi8>
    %1 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> memref<?x1x128x1x1x128xi8>
    %2 = "neura.constant"() <{value = 1 : i64}> : () -> i64
    %3 = "neura.constant"() <{value = 128 : i64}> : () -> i64
    %4 = "neura.constant"() <{value = 0 : i64}> : () -> i64
    neura.br %4, %3 : i64, i64 to ^bb1
  ^bb1(%5: i64, %6: i64):  // 2 preds: ^bb0, ^bb5
    %7 = "neura.icmp"(%5, %6) <{cmpType = "slt"}> : (i64, i64) -> i1
    neura.cond_br %7 : i1 then %4 : i64 to ^bb2 else to ^bb6
  ^bb2(%8: i64):  // pred: ^bb1
    neura.br %8, %3 : i64, i64 to ^bb3
  ^bb3(%9: i64, %10: i64):  // 2 preds: ^bb2, ^bb4
    %11 = "neura.icmp"(%9, %10) <{cmpType = "slt"}> : (i64, i64) -> i1
    neura.cond_br %11 : i1 then %0, %4, %9, %1, %5, %2, %3 : memref<?x1x1x1x1x128xi8>, i64, i64, memref<?x1x128x1x1x128xi8>, i64, i64, i64 to ^bb4 else %5, %2, %3 : i64, i64, i64 to ^bb5
  ^bb4(%12: memref<?x1x1x1x1x128xi8>, %13: i64, %14: i64, %15: memref<?x1x128x1x1x128xi8>, %16: i64, %17: i64, %18: i64):  // pred: ^bb3
    %19 = neura.load_indexed %12[%13, %13, %13, %13, %13, %14 : i64, i64, i64, i64, i64, i64] memref<?x1x1x1x1x128xi8> : i8
    neura.store_indexed %19 to %15[%13, %13, %16, %13, %13, %14 : i64, i64, i64, i64, i64, i64] memref<?x1x128x1x1x128xi8> : i8
    %20 = "neura.add"(%14, %17) : (i64, i64) -> i64
    neura.br %20, %18 : i64, i64 to ^bb3
  ^bb5(%21: i64, %22: i64, %23: i64):  // pred: ^bb3
    %24 = "neura.add"(%21, %22) : (i64, i64) -> i64
    neura.br %24, %23 : i64, i64 to ^bb1
  ^bb6:  // pred: ^bb1
    "neura.return"() : () -> ()
  }
```

Therefore, in this pr:
- Fix the bug that cannot handle such a case in current `--canonicalize-live-in` pass
- We are able to handle arbitrary control flow now, but may introduce non-sense/redundant `phi-grant_predicate-ctrl_mov` chain
- These redundancies can be removed through `--fuse-control-flow` in the future. Since they are generated by our canonicalization, they have regular dependencies and are easy to remove.

And the new canonicalized ir looks like:
```
  func.func @_Z10bert_node1PA1_A1_A1_A1_A128_bPA1_A128_S1_(%arg0: memref<?x1x1x1x1x128xi8>, %arg1: memref<?x1x128x1x1x128xi8>) attributes {accelerator = "neura", llvm.linkage = #llvm.linkage<external>} {
    %0 = "neura.constant"() <{predicate = true, value = "%arg0"}> : () -> memref<?x1x1x1x1x128xi8>
    %1 = "neura.constant"() <{predicate = true, value = "%arg1"}> : () -> memref<?x1x128x1x1x128xi8>
    %2 = "neura.constant"() <{value = 1 : i64}> : () -> i64
    %3 = "neura.constant"() <{value = 128 : i64}> : () -> i64
    %4 = "neura.constant"() <{value = 0 : i64}> : () -> i64
    neura.br %4, %3, %4, %0, %1, %2 : i64, i64, i64, memref<?x1x1x1x1x128xi8>, memref<?x1x128x1x1x128xi8>, i64 to ^bb1
  ^bb1(%5: i64, %6: i64, %7: i64, %8: memref<?x1x1x1x1x128xi8>, %9: memref<?x1x128x1x1x128xi8>, %10: i64):  // 2 preds: ^bb0, ^bb5
    %11 = "neura.icmp"(%5, %6) <{cmpType = "slt"}> : (i64, i64) -> i1
    neura.cond_br %11 : i1 then %7, %6, %8, %9, %5, %10 : i64, i64, memref<?x1x1x1x1x128xi8>, memref<?x1x128x1x1x128xi8>, i64, i64 to ^bb2 else to ^bb6
  ^bb2(%12: i64, %13: i64, %14: memref<?x1x1x1x1x128xi8>, %15: memref<?x1x128x1x1x128xi8>, %16: i64, %17: i64):  // pred: ^bb1
    neura.br %12, %13, %14, %12, %15, %16, %17 : i64, i64, memref<?x1x1x1x1x128xi8>, i64, memref<?x1x128x1x1x128xi8>, i64, i64 to ^bb3
  ^bb3(%18: i64, %19: i64, %20: memref<?x1x1x1x1x128xi8>, %21: i64, %22: memref<?x1x128x1x1x128xi8>, %23: i64, %24: i64):  // 2 preds: ^bb2, ^bb4
    %25 = "neura.icmp"(%18, %19) <{cmpType = "slt"}> : (i64, i64) -> i1
    neura.cond_br %25 : i1 then %20, %21, %18, %22, %23, %24, %19 : memref<?x1x1x1x1x128xi8>, i64, i64, memref<?x1x128x1x1x128xi8>, i64, i64, i64 to ^bb4 else %23, %24, %19, %21, %20, %22 : i64, i64, i64, i64, memref<?x1x1x1x1x128xi8>, memref<?x1x128x1x1x128xi8> to ^bb5
  ^bb4(%26: memref<?x1x1x1x1x128xi8>, %27: i64, %28: i64, %29: memref<?x1x128x1x1x128xi8>, %30: i64, %31: i64, %32: i64):  // pred: ^bb3
    %33 = neura.load_indexed %26[%27, %27, %27, %27, %27, %28 : i64, i64, i64, i64, i64, i64] memref<?x1x1x1x1x128xi8> : i8
    neura.store_indexed %33 to %29[%27, %27, %30, %27, %27, %28 : i64, i64, i64, i64, i64, i64] memref<?x1x128x1x1x128xi8> : i8
    %34 = "neura.add"(%28, %31) : (i64, i64) -> i64
    neura.br %34, %32, %26, %27, %29, %30, %31 : i64, i64, memref<?x1x1x1x1x128xi8>, i64, memref<?x1x128x1x1x128xi8>, i64, i64 to ^bb3
  ^bb5(%35: i64, %36: i64, %37: i64, %38: i64, %39: memref<?x1x1x1x1x128xi8>, %40: memref<?x1x128x1x1x128xi8>):  // pred: ^bb3
    %41 = "neura.add"(%35, %36) : (i64, i64) -> i64
    neura.br %41, %37, %38, %39, %40, %36 : i64, i64, i64, memref<?x1x1x1x1x128xi8>, memref<?x1x128x1x1x128xi8>, i64 to ^bb1
  ^bb6:  // pred: ^bb1
    "neura.return"() : () -> ()
  }
```