### PR TITLE
Support more test cases for mapping

### DIFF
--- a/include/NeuraDialect/NeuraOps.td
+++ b/include/NeuraDialect/NeuraOps.td
@@ -43,9 +43,23 @@ def Neura_MulOp : Op<NeuraDialect, "mul"> {
 
 def Neura_DivOp : Op<NeuraDialect, "div"> {
   let summary = "Integer division operation";
-  let arguments = (ins AnyType:$lhs, AnyType:$rhs, Optional<AnyType>:$predicate);
+  let arguments = (ins AnyType:$lhs, Optional<AnyType>:$rhs);
   let results = (outs AnyType:$result);
   // let assemblyFormat = "$lhs `,` $rhs `,` $predicate attr-dict `:` type($result)";
+  let traits = [SameOperandsAndResultElementType];
+}
+
+def Neura_RemOp : Op<NeuraDialect, "rem">{
+  let summary = "Integer remainder operation";
+  let description = [{
+    Performs an integer remainder operation, computing the result of
+    a % b, where % is the remainder operator.
+    
+    Example:
+      %result = neura.rem %a, %b : i32
+  }];
+  let arguments = (ins AnyType:$lhs, Optional<AnyType>:$rhs);
+  let results = (outs AnyType:$result);
   let traits = [SameOperandsAndResultElementType];
 }
 
@@ -63,8 +77,8 @@ def Neura_FAddOp : Op<NeuraDialect, "fadd"> {
 def Neura_FSubOp: Op<NeuraDialect, "fsub"> {
   let summary = "Floating substraction operation";
   let opName = "fsub";
-  let arguments = (ins AnyFloat:$lhs, AnyFloat:$rhs, Optional<AnyType>:$predicate);
-  let results = (outs AnyFloat:$result);
+  let arguments = (ins AnyType:$lhs, Optional<AnyType>:$rhs);
+  let results = (outs AnyType:$result);
   // let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($result)";
   let traits = [SameOperandsAndResultElementType];
 }
@@ -222,9 +236,9 @@ def Neura_AllocaOp : Op<NeuraDialect, "alloca"> {
       %ptr = neura.alloca %size : !neura.data<i32, i1> -> !llvm.ptr
   }];
   
-  let arguments = (ins AnyType:$size);
+  let arguments = (ins Optional<AnyType>:$size);
   let results = (outs AnyType:$result);
-  let assemblyFormat = "$size attr-dict `:` type($size) `->` type($result)";
+  let assemblyFormat = "($size^ `:` type($size))? attr-dict `->` type($result)";
 }
 
 // Defines a sign extension operation.
@@ -259,6 +273,20 @@ def Neura_ZExtOp : Op<NeuraDialect, "zext"> {
   let assemblyFormat = "$value attr-dict `:` type($value) `->` type($result)";
 }
 
+// Defines a logical shift left operation.
+def Neura_ShlOp : Op<NeuraDialect, "shl"> {
+  let summary = "Logical shift left operation";
+  let description = [{
+    Performs a logical left shift on an integer value.
+    Similar to llvm.shl, but works with predicated values.
+
+    Example:
+      %shifted = neura.shl %value, %shiftAmount : !neura.data<i32, i1> -> !neura.data<i32, i1>
+  }];
+  let arguments = (ins AnyType:$value, Optional<AnyType>:$shiftAmount);
+  let results = (outs AnyType:$result);
+}
+ 
 // ----------------------------------------------------
 // Defines vector operations.
 

--- a/lib/Conversion/ArithToNeura/ArithToNeuraPass.cpp
+++ b/lib/Conversion/ArithToNeura/ArithToNeuraPass.cpp
@@ -98,8 +98,7 @@ struct ArithSubFToNeuraFSub : public OpRewritePattern<mlir::arith::SubFOp> {
     Type result_type = op.getType();
 
     // Optional predicate: default to null.
-    rewriter.replaceOpWithNewOp<neura::FSubOp>(op, result_type, lhs, rhs,
-                                               nullptr);
+    rewriter.replaceOpWithNewOp<neura::FSubOp>(op, result_type, lhs, rhs);
     return success();
   }
 };
@@ -144,8 +143,7 @@ struct ArithDivSIToNeuraDiv : public OpRewritePattern<mlir::arith::DivSIOp> {
     Type result_type = op.getType();
     // Converts arith DivSIOp to Neura DivOp.
     // Optional predicate: default to null.
-    rewriter.replaceOpWithNewOp<neura::DivOp>(op, result_type, lhs, rhs,
-                                              nullptr);
+    rewriter.replaceOpWithNewOp<neura::DivOp>(op, result_type, lhs, rhs);
     return success();
   }
 };
@@ -176,8 +174,7 @@ struct ArithRemSIToNeuraOp : public OpRewritePattern<mlir::arith::RemSIOp> {
     Location loc = op.getLoc();
     // Converts arith RemSIOp to basic Neura Op.
     // Optional predicate: default to null.
-    Value div =
-        rewriter.create<neura::DivOp>(loc, result_type, lhs, rhs, nullptr);
+    Value div = rewriter.create<neura::DivOp>(loc, result_type, lhs, rhs);
     Value mul = rewriter.create<neura::MulOp>(loc, result_type, rhs, div);
     Value rem = rewriter.create<neura::SubOp>(loc, result_type, lhs, mul);
 

--- a/lib/Conversion/MemRefToNeura/MemRefToNeuraPass.cpp
+++ b/lib/Conversion/MemRefToNeura/MemRefToNeuraPass.cpp
@@ -8,6 +8,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/Support/LogicalResult.h"
 
 using namespace mlir;
 using namespace mlir::neura;
@@ -46,6 +47,30 @@ struct MemRefStoreLowering : public OpRewritePattern<memref::StoreOp> {
   }
 };
 
+struct MemRefAllocaToNeuraAlloca : public OpRewritePattern<memref::AllocaOp> {
+  using OpRewritePattern<memref::AllocaOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(memref::AllocaOp alloca_op,
+                                PatternRewriter &rewriter) const override {
+    // Gets the result type.
+    Type result_type = alloca_op.getType();
+
+    // Checks if we have dynamic dimensions.
+    if (!alloca_op.getDynamicSizes().empty()) {
+      // For dynamic dimensions, we need to create the alloca with the size
+      // arguments.
+      rewriter.replaceOpWithNewOp<neura::AllocaOp>(alloca_op, result_type,
+                                                   alloca_op.getDynamicSizes());
+    } else {
+      // For static dimensions, we can create the alloca without size arguments.
+      rewriter.replaceOpWithNewOp<neura::AllocaOp>(alloca_op, result_type,
+                                                   Value());
+    }
+
+    return success();
+  }
+};
+
 struct LowerMemRefToNeuraPass
     : public PassWrapper<LowerMemRefToNeuraPass, OperationPass<ModuleOp>> {
 
@@ -64,8 +89,11 @@ struct LowerMemRefToNeuraPass
     ModuleOp module_op = getOperation();
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(&getContext());
+
     patterns.add<MemRefLoadLowering>(context);
     patterns.add<MemRefStoreLowering>(context);
+    patterns.add<MemRefAllocaToNeuraAlloca>(context);
+
     module_op.walk([&](func::FuncOp func_op) {
       if (func_op->hasAttr(mlir::accel::kAcceleratorAttr)) {
         auto target =

--- a/lib/NeuraDialect/Architecture/Architecture.cpp
+++ b/lib/NeuraDialect/Architecture/Architecture.cpp
@@ -209,8 +209,8 @@ Architecture::Architecture(int width, int height) {
     for (int x = 0; x < width; ++x) {
       // Gets the tile by coordinates.
       Tile *tile = getTile(x, y);
-      const int kNUM_REGS_PER_REGFILE = 4;
-      const int kNUM_REGFILES_PER_CLUSTER = 2;
+      const int kNUM_REGS_PER_REGFILE = 8;
+      const int kNUM_REGFILES_PER_CLUSTER = 4;
 
       // Assembles register files into a cluster.
       RegisterFileCluster *register_file_cluster =

--- a/lib/NeuraDialect/Transforms/MapToAcceleratorPass.cpp
+++ b/lib/NeuraDialect/Transforms/MapToAcceleratorPass.cpp
@@ -173,7 +173,7 @@ struct MapToAcceleratorPass
       int res_mii = calculateResMii(func, architecture);
 
       const int possibleMinII = std::max(rec_mii, res_mii);
-      constexpr int maxII = 15;
+      constexpr int maxII = 20;
       std::vector<Operation *> topologically_sorted_ops =
           getTopologicallySortedOps(func);
       if (topologically_sorted_ops.empty()) {

--- a/lib/NeuraDialect/Transforms/Optimizations/HwAgnosticOpt/FoldConstantPass.cpp
+++ b/lib/NeuraDialect/Transforms/Optimizations/HwAgnosticOpt/FoldConstantPass.cpp
@@ -205,6 +205,34 @@ struct FuseFAddRhsConstantPattern
   }
 };
 
+struct FuseDivRhsConstantPattern : public FuseRhsConstantPattern<neura::DivOp> {
+  using FuseRhsConstantPattern<neura::DivOp>::FuseRhsConstantPattern;
+
+  Operation *
+  createOpWithFusedRhsConstant(neura::DivOp op, Attribute rhs_const_value,
+                               PatternRewriter &rewriter) const override {
+    auto fused_op = rewriter.create<neura::DivOp>(
+        op.getLoc(), op.getResult().getType(), op.getLhs(),
+        /*rhs=*/nullptr);
+    addConstantAttribute(fused_op, "rhs_const_value", rhs_const_value);
+    return fused_op;
+  }
+};
+
+struct FuseRemRhsConstantPattern : public FuseRhsConstantPattern<neura::RemOp> {
+  using FuseRhsConstantPattern<neura::RemOp>::FuseRhsConstantPattern;
+
+  Operation *
+  createOpWithFusedRhsConstant(neura::RemOp op, Attribute rhs_const_value,
+                               PatternRewriter &rewriter) const override {
+    auto fused_op = rewriter.create<neura::RemOp>(
+        op.getLoc(), op.getResult().getType(), op.getLhs(),
+        /*rhs=*/nullptr);
+    addConstantAttribute(fused_op, "rhs_const_value", rhs_const_value);
+    return fused_op;
+  }
+};
+
 // =========================================
 // FoldConstantPass Implementation
 // =========================================
@@ -226,6 +254,8 @@ struct FoldConstantPass
     patterns.add<FuseMulRhsConstantPattern>(&getContext());
     patterns.add<FuseICmpRhsConstantPattern>(&getContext());
     patterns.add<FuseFAddRhsConstantPattern>(&getContext());
+    patterns.add<FuseDivRhsConstantPattern>(&getContext());
+    patterns.add<FuseRemRhsConstantPattern>(&getContext());
 
     patterns.add<FuseConstantAndGrantPattern>(&getContext());
     FrozenRewritePatternSet frozen(std::move(patterns));

--- a/test/c2llvm2mlir/nested_loop/test.mlir
+++ b/test/c2llvm2mlir/nested_loop/test.mlir
@@ -1,5 +1,5 @@
-// RUN: clang++ -S -emit-llvm kernel.cpp -o kernel.ll
-// RUN: mlir-translate --import-llvm kernel.ll -o kernel.mlir
+// RUN: clang++ -S -emit-llvm kernel.cpp -o %t-kernel.ll
+// RUN: mlir-translate --import-llvm %t-kernel.ll -o %t-kernel.mlir
 
 // RUN: mlir-neura-opt --assign-accelerator \
 // RUN:   --lower-llvm-to-neura \
@@ -7,7 +7,7 @@
 // RUN:   --leverage-predicated-value \
 // RUN:   --transform-ctrl-to-data-flow \
 // RUN:   --fold-constant \
-// RUN:   --insert-data-mov kernel.mlir | FileCheck %s --check-prefix=CHECK-LLVM2NEURA
+// RUN:   --insert-data-mov %t-kernel.mlir | FileCheck %s --check-prefix=CHECK-LLVM2NEURA
 
 // RUN: mlir-neura-opt --assign-accelerator \
 // RUN:   --lower-llvm-to-neura \
@@ -16,7 +16,7 @@
 // RUN:   --transform-ctrl-to-data-flow \
 // RUN:   --fold-constant \
 // RUN:   --insert-data-mov \
-// RUN:   --map-to-accelerator="mapping-strategy=heuristic backtrack-config=simple" kernel.mlir | FileCheck %s --check-prefix=CHECK-LLVM2NEURA-MAP
+// RUN:   --map-to-accelerator="mapping-strategy=heuristic backtrack-config=simple" %t-kernel.mlir | FileCheck %s --check-prefix=CHECK-LLVM2NEURA-MAP
 
 // CHECK-LLVM2NEURA: accelerator = "neura"
 // CHECK-LLVM2NEURA: %25 = neura.alloca %24 : !neura.data<i32, i1> -> !neura.data<!llvm.ptr, i1>
@@ -24,4 +24,4 @@
 // CHECK-LLVM2NEURA: %175 = neura.sext %174 : !neura.data<i32, i1> -> !neura.data<i64, i1>
 // CHECK-LLVM2NEURA: %194 = "neura.mul"(%192, %193) : (!neura.data<i32, i1>, !neura.data<i32, i1>) -> !neura.data<i32, i1>
 
-// CHECK-LLVM2NEURA-MAP: func.func @_Z6kernelPiS_S_(%arg0: !llvm.ptr {llvm.noundef}, %arg1: !llvm.ptr {llvm.noundef}, %arg2: !llvm.ptr {llvm.noundef}) -> !llvm.void attributes {CConv = #llvm.cconv<ccc>, accelerator = "neura", frame_pointer = #llvm.framePointerKind<all>, linkage = #llvm.linkage<external>, no_inline, no_unwind, optimize_none, passthrough = ["mustprogress", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], target_cpu = "x86-64", target_features = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, tune_cpu = "generic", unnamed_addr = 0 : i64, visibility_ = 0 : i64} {
+// CHECK-LLVM2NEURA-MAP: func.func @_Z6kernelPiS_S_(%arg0: !llvm.ptr {llvm.noundef}, %arg1: !llvm.ptr {llvm.noundef}, %arg2: !llvm.ptr {llvm.noundef}) -> !llvm.void attributes {CConv = #llvm.cconv<ccc>, accelerator = "neura", frame_pointer = #llvm.framePointerKind<all>, linkage = #llvm.linkage<external>, mapping_info = {compiled_ii = 17 : i32, mapping_mode = "spatial-temporal", mapping_strategy = "heuristic", rec_mii = 9 : i32, res_mii = 6 : i32, x_tiles = 4 : i32, y_tiles = 4 : i32}, no_inline, no_unwind, optimize_none, passthrough = ["mustprogress", ["uwtable", "2"], ["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], target_cpu = "x86-64", target_features = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, tune_cpu = "generic", unnamed_addr = 0 : i64, visibility_ = 0 : i64} {

--- a/test/code_gen/test_code_generate.mlir
+++ b/test/code_gen/test_code_generate.mlir
@@ -68,63 +68,63 @@ func.func @loop_test() -> f32 {
 //   written into local register $20.
 //
 
-// YAML:       - column: 1
-// YAML-NEXT:      row: 0
-// YAML-NEXT:      core_id: "1"
-// YAML-NEXT:      entries:
-// YAML-NEXT:        - entry_id: "entry0"
-// YAML-NEXT:          instructions:
-// YAML-NEXT:            - timestep: 1
-// YAML-NEXT:              operations:
-// YAML-NEXT:                - opcode: "GRANT_ONCE"
-// YAML-NEXT:                  src_operands:
-// YAML-NEXT:                    - operand: "WEST"
-// YAML-NEXT:                      color: "RED"
-// YAML-NEXT:                  dst_operands:
-// YAML-NEXT:                    - operand: "NORTH"
-// YAML-NEXT:                      color: "RED"
-// YAML-NEXT:            - timestep: 2
-// YAML-NEXT:              operations:
-// YAML-NEXT:                - opcode: "GRANT_ONCE"
-// YAML-NEXT:                  src_operands:
-// YAML-NEXT:                    - operand: "WEST"
-// YAML-NEXT:                      color: "RED"
-// YAML-NEXT:                  dst_operands:
-// YAML-NEXT:                    - operand: "$8"
-// YAML-NEXT:                      color: "RED"
-// YAML-NEXT:            - timestep: 3
-// YAML-NEXT:              operations:
-// YAML-NEXT:                - opcode: "PHI"
-// YAML-NEXT:                  src_operands:
-// YAML-NEXT:                    - operand: "$9"
-// YAML-NEXT:                      color: "RED"
-// YAML-NEXT:                    - operand: "$8"
-// YAML-NEXT:                      color: "RED"
-// YAML-NEXT:                  dst_operands:
-// YAML-NEXT:                    - operand: "NORTH"
-// YAML-NEXT:                      color: "RED"
-// YAML-NEXT:                    - operand: "$8"
-// YAML-NEXT:                      color: "RED"
-// YAML-NEXT:            - timestep: 4
-// YAML-NEXT:              operations:
-// YAML-NEXT:                - opcode: "DATA_MOV"
-// YAML-NEXT:                  src_operands:
-// YAML-NEXT:                    - operand: "EAST"
-// YAML-NEXT:                      color: "RED"
-// YAML-NEXT:                  dst_operands:
-// YAML-NEXT:                    - operand: "NORTH"
-// YAML-NEXT:                      color: "RED"
-// YAML-NEXT:            - timestep: 5
-// YAML-NEXT:              operations:
-// YAML-NEXT:                - opcode: "GRANT_PREDICATE"
-// YAML-NEXT:                  src_operands:
-// YAML-NEXT:                    - operand: "$8"
-// YAML-NEXT:                      color: "RED"
-// YAML-NEXT:                    - operand: "NORTH"
-// YAML-NEXT:                      color: "RED"
-// YAML-NEXT:                  dst_operands:
-// YAML-NEXT:                    - operand: "$9"
-// YAML-NEXT:                      color: "RED"
+// YAML:          - column: 1
+// YAML-NEXT:       row: 0
+// YAML-NEXT:       core_id: "1"
+// YAML-NEXT:       entries:
+// YAML-NEXT:         - entry_id: "entry0"
+// YAML-NEXT:           instructions:
+// YAML-NEXT:             - timestep: 1
+// YAML-NEXT:               operations:
+// YAML-NEXT:                 - opcode: "GRANT_ONCE"
+// YAML-NEXT:                   src_operands:
+// YAML-NEXT:                     - operand: "WEST"
+// YAML-NEXT:                       color: "RED"
+// YAML-NEXT:                   dst_operands:
+// YAML-NEXT:                     - operand: "NORTH"
+// YAML-NEXT:                       color: "RED"
+// YAML-NEXT:             - timestep: 2
+// YAML-NEXT:               operations:
+// YAML-NEXT:                 - opcode: "GRANT_ONCE"
+// YAML-NEXT:                   src_operands:
+// YAML-NEXT:                     - operand: "WEST"
+// YAML-NEXT:                       color: "RED"
+// YAML-NEXT:                   dst_operands:
+// YAML-NEXT:                     - operand: "$32"
+// YAML-NEXT:                       color: "RED"
+// YAML-NEXT:             - timestep: 3
+// YAML-NEXT:               operations:
+// YAML-NEXT:                 - opcode: "PHI"
+// YAML-NEXT:                   src_operands:
+// YAML-NEXT:                     - operand: "$33"
+// YAML-NEXT:                       color: "RED"
+// YAML-NEXT:                     - operand: "$32"
+// YAML-NEXT:                       color: "RED"
+// YAML-NEXT:                   dst_operands:
+// YAML-NEXT:                     - operand: "NORTH"
+// YAML-NEXT:                       color: "RED"
+// YAML-NEXT:                     - operand: "$32"
+// YAML-NEXT:                       color: "RED"
+// YAML-NEXT:             - timestep: 4
+// YAML-NEXT:               operations:
+// YAML-NEXT:                 - opcode: "DATA_MOV"
+// YAML-NEXT:                   src_operands:
+// YAML-NEXT:                     - operand: "EAST"
+// YAML-NEXT:                       color: "RED"
+// YAML-NEXT:                   dst_operands:
+// YAML-NEXT:                     - operand: "NORTH"
+// YAML-NEXT:                       color: "RED"
+// YAML-NEXT:             - timestep: 5
+// YAML-NEXT:               operations:
+// YAML-NEXT:                 - opcode: "GRANT_PREDICATE"
+// YAML-NEXT:                   src_operands:
+// YAML-NEXT:                     - operand: "$32"
+// YAML-NEXT:                       color: "RED"
+// YAML-NEXT:                     - operand: "NORTH"
+// YAML-NEXT:                       color: "RED"
+// YAML-NEXT:                   dst_operands:
+// YAML-NEXT:                     - operand: "$33"
+// YAML-NEXT:                       color: "RED"
 
 
 // ASM:      PE(0,0):


### PR DESCRIPTION
In this pr, we make the following changes to make it support more mapping cases:

- Add `neura.shl` and `neura.rem` operations
- Add more constant folding patterns
- Make the `neura.alloca` supporting lowering from `memref.alloca`
- Increase the `maxII` to 20
- Increase the number of registers in each tile to 32