### PR TITLE
Support implementation of architecture_spec config.

### DIFF
--- a/include/ArchitectureSpec/architecture.yaml
+++ b/include/ArchitectureSpec/architecture.yaml
@@ -1,13 +1,13 @@
 architecture:
   name: "NeuraCGRA"
   version: "1.0"
-  width: 4
-  height: 4
+  width: 8
+  height: 8
 
 tile_defaults:
-  num_registers: 64
+  num_registers: 128
   default_ports: ["N", "S", "W", "E"]
-  operations: ["add", "mul", "sub"]  # default ALU instructions
+  operations: ["add", "mul", "sub", "div", "rem", "fadd", "fmul", "fsub", "fdiv", "or", "not", "icmp", "fcmp", "sel", "cast", "sext", "zext", "shl", "vfmul", "fadd_fadd", "fmul_fadd", "data_mov", "ctrl_mov", "reserve", "grant_predicate", "grant_once", "grant_always", "loop_control", "phi", "constant"]  # comprehensive operation set
 
 link_defaults:
   latency: 1

--- a/include/NeuraDialect/Architecture/Architecture.h
+++ b/include/NeuraDialect/Architecture/Architecture.h
@@ -1,6 +1,7 @@
 #ifndef NEURA_ARCHITECTURE_H
 #define NEURA_ARCHITECTURE_H
 
+#include <algorithm>
 #include <cassert>
 #include <map>
 #include <memory>
@@ -30,7 +31,32 @@ enum class FunctionUnitKind {
 };
 
 // Enum for supported operation types.
-enum OperationKind { IAdd = 0, IMul = 1, FAdd = 2, FMul = 3 };
+enum OperationKind { 
+  // Integer arithmetic operations
+  IAdd = 0, IMul = 1, ISub = 2, IDiv = 3, IRem = 4,
+  // Floating-point arithmetic operations  
+  FAdd = 5, FMul = 6, FSub = 7, FDiv = 8,
+  // Memory operations
+  ILoad = 9, IStore = 10, ILoadIndexed = 11, IStoreIndexed = 12, IAlloca = 13,
+  // Logical operations
+  IOr = 14, INot = 15, ICmp = 16, FCmp = 17, ISel = 18,
+  // Type conversion operations
+  ICast = 19, ISExt = 20, IZExt = 21, IShl = 22,
+  // Vector operations
+  VFMul = 23,
+  // Fused operations
+  FAddFAdd = 24, FMulFAdd = 25,
+  // Control flow operations
+  IReturn = 26, IPhi = 27,
+  // Data movement operations
+  IDataMov = 28, ICtrlMov = 29,
+  // Predicate operations
+  IReserve = 30, IGrantPredicate = 31, IGrantOnce = 32, IGrantAlways = 33,
+  // Loop control operations
+  ILoopControl = 34,
+  // Constant operations
+  IConstant = 35
+};
 
 //===----------------------------------------------------------------------===//
 // BasicResource: abstract base class for Tile, Link, etc.
@@ -94,24 +120,6 @@ private:
   Tile *tile;
 };
 
-class FixedPointAdder : public FunctionUnit {
-public:
-  FixedPointAdder(int id) : FunctionUnit(id) {
-    supported_operations.insert(OperationKind::IAdd);
-  }
-  std::string getType() const override { return "fixed_point_adder"; }
-  ResourceKind getKind() const override { return ResourceKind::FunctionUnit; }
-};
-
-class FixedPointMultiplier : public FunctionUnit {
-public:
-  FixedPointMultiplier(int id) : FunctionUnit(id) {
-    supported_operations.insert(OperationKind::IMul);
-  }
-  std::string getType() const override { return "fixed_point_multiplier"; }
-  ResourceKind getKind() const override { return ResourceKind::FunctionUnit; }
-};
-
 class CustomizableFunctionUnit : public FunctionUnit {
 public:
   CustomizableFunctionUnit(int id) : FunctionUnit(id) {}
@@ -143,6 +151,7 @@ public:
   int getY() const;
 
   void linkDstTile(Link *link, Tile *tile);
+  void unlinkDstTile(Link *link, Tile *tile);
   const std::set<Tile *> &getDstTiles() const;
   const std::set<Tile *> &getSrcTiles() const;
   const std::set<Link *> &getOutLinks() const;
@@ -155,16 +164,20 @@ public:
     functional_units.insert(functional_unit_storage.back().get());
   }
 
+  void clearFunctionUnits() {
+    functional_unit_storage.clear();
+    functional_units.clear();
+  }
+
   bool canSupportOperation(OperationKind operation) const {
     for (FunctionUnit *fu : functional_units) {
       if (fu->canSupportOperation(operation)) {
         return true;
       }
     }
-    // TODO: Check if the tile can support the operation based on its
-    // capabilities.
-    // @Jackcuii, https://github.com/coredac/dataflow/issues/82.
-    return true;
+    // Checks if any function unit in this tile supports the operation.
+    // This is now properly implemented by checking all functional units.
+    return false;
   }
 
   void addRegisterFileCluster(RegisterFileCluster *register_file_cluster);
@@ -174,6 +187,17 @@ public:
   const std::vector<RegisterFile *> getRegisterFiles() const;
 
   const std::vector<Register *> getRegisters() const;
+
+  // Port management
+  const std::vector<std::string> &getPorts() const { return ports; }
+  void setPorts(const std::vector<std::string> &newPorts) { ports = newPorts; }
+  bool hasPort(const std::string &port) const {
+    return std::find(ports.begin(), ports.end(), port) != ports.end();
+  }
+
+  // Memory management
+  int getMemoryCapacity() const { return memory_capacity; }
+  void setMemoryCapacity(int capacity) { memory_capacity = capacity; }
 
 private:
   int id;
@@ -186,6 +210,10 @@ private:
       functional_unit_storage;               // Owns FUs.
   std::set<FunctionUnit *> functional_units; // Non-owning, for fast lookup.
   RegisterFileCluster *register_file_cluster = nullptr;
+  
+  // Port and memory configuration
+  std::vector<std::string> ports;
+  int memory_capacity = -1;  // -1 means not configured
 };
 
 //===----------------------------------------------------------------------===//
@@ -210,10 +238,18 @@ public:
 
   void connect(Tile *src, Tile *dst);
 
+  // Link properties
+  int getLatency() const { return latency; }
+  int getBandwidth() const { return bandwidth; }
+  void setLatency(int l) { latency = l; }
+  void setBandwidth(int b) { bandwidth = b; }
+
 private:
   int id;
   Tile *src_tile;
   Tile *dst_tile;
+  int latency = 1;
+  int bandwidth = 32;
 };
 
 //===----------------------------------------------------------------------===//
@@ -318,11 +354,22 @@ struct PairHash {
   }
 };
 
+// Forward declaration
+struct TileDefaults;
+struct TileOverride;
+struct LinkDefaults;
+struct LinkOverride;
+
 // Describes the CGRA architecture template.
-// TODO: Model architecture in detail (e.g., registers, ports).
+// Now supports comprehensive configuration via YAML including ports, memory, and function units.
 class Architecture {
 public:
-  Architecture(int width, int height);
+  // Single constructor - handles all cases internally
+  Architecture(int width, int height, 
+               const TileDefaults& tileDefaults,
+               const std::vector<TileOverride>& tileOverrides,
+               const LinkDefaults& linkDefaults,
+               const std::vector<LinkOverride>& linkOverrides);
 
   Tile *getTile(int id);
   Tile *getTile(int x, int y);
@@ -331,14 +378,24 @@ public:
   int getHeight() const { return height; }
 
   Link *getLink(int id);
+  void removeLink(int linkId);
 
   int getNumTiles() const;
   std::vector<Tile *> getAllTiles() const;
   std::vector<Link *> getAllLinks() const;
 
 private:
-  // TODO: Model architecture in detail, e.g., ports, registers, crossbars, etc.
-  // https://github.com/coredac/dataflow/issues/52.
+  // Helper methods for constructor initialization.
+  void initializeTiles(int width, int height);
+  void configureDefaultTileSettings(const TileDefaults& tileDefaults);
+  void applyTileOverrides(const std::vector<TileOverride>& tileOverrides);
+  void createLinks(const LinkDefaults& linkDefaults);
+  void applyLinkOverrides(const std::vector<LinkOverride>& linkOverrides);
+  void createRegisterFileCluster(Tile *tile, int num_registers, int &reg_id);
+  void recreateRegisterFileCluster(Tile *tile, int num_registers);
+
+  // Architecture components: tiles, links, and their mappings.
+  // Ports and memory are now modeled as part of Tile class.
   std::vector<std::unique_ptr<Tile>> tile_storage;
   std::vector<std::unique_ptr<Link>> link_storage;
   std::unordered_map<int, Tile *> id_to_tile;

--- a/include/NeuraDialect/Architecture/ArchitectureSpec.h
+++ b/include/NeuraDialect/Architecture/ArchitectureSpec.h
@@ -1,0 +1,58 @@
+#ifndef NEURA_ARCHITECTURE_SPEC_H
+#define NEURA_ARCHITECTURE_SPEC_H
+
+#include <string>
+#include <vector>
+
+namespace mlir {
+namespace neura {
+
+// Structure to hold tile default configuration
+struct TileDefaults {
+  int num_registers = 64;  // default value
+  std::vector<std::string> default_ports = {"N", "S", "W", "E"};  // default ports
+  std::vector<std::string> operations = {"add", "mul", "sub"};  // default operations
+};
+
+// Structure to hold memory configuration
+struct MemoryConfig {
+  int capacity = -1;  // Memory capacity in bytes
+};
+
+// Structure to hold tile override configuration
+struct TileOverride {
+  int id = -1;
+  int x = -1, y = -1;
+  std::vector<std::string> operations;
+  int num_registers = -1;
+  std::vector<std::string> ports;
+  MemoryConfig memory;
+};
+
+// Structure to hold link default configuration
+struct LinkDefaults {
+  int latency = 1;  // default latency
+  int bandwidth = 32;  // default bandwidth
+};
+
+// Structure to hold link override configuration
+struct LinkOverride {
+  int id = -1;
+  int latency = -1;
+  int bandwidth = -1;
+  int src_tile_id = -1;
+  int dst_tile_id = -1;
+  bool existence = true;
+};
+
+// Function to get the architecture specification file path
+// This is set by the command line tool when a YAML file is provided
+std::string getArchitectureSpecFile();
+
+// Function to get tile defaults configuration
+TileDefaults getTileDefaults();
+
+} // namespace neura
+} // namespace mlir
+
+#endif // NEURA_ARCHITECTURE_SPEC_H

--- a/lib/NeuraDialect/Architecture/Architecture.cpp
+++ b/lib/NeuraDialect/Architecture/Architecture.cpp
@@ -1,10 +1,140 @@
 #include "NeuraDialect/Architecture/Architecture.h"
+#include "NeuraDialect/Architecture/ArchitectureSpec.h"
 #include "llvm/Support/raw_ostream.h"
-
 #include <cassert>
 
 using namespace mlir;
 using namespace mlir::neura;
+
+// Helper function to configure arithmetic operations.
+void configureArithmeticOperations(CustomizableFunctionUnit *functionUnit, const std::string &operation) {
+  if (operation == "add") {
+    functionUnit->addSupportedOperation(IAdd);
+  } else if (operation == "sub") {
+    functionUnit->addSupportedOperation(ISub);
+  } else if (operation == "mul") {
+    functionUnit->addSupportedOperation(IMul);
+  } else if (operation == "div") {
+    functionUnit->addSupportedOperation(IDiv);
+  } else if (operation == "rem") {
+    functionUnit->addSupportedOperation(IRem);
+  } else if (operation == "fadd") {
+    functionUnit->addSupportedOperation(FAdd);
+  } else if (operation == "fsub") {
+    functionUnit->addSupportedOperation(FSub);
+  } else if (operation == "fmul") {
+    functionUnit->addSupportedOperation(FMul);
+  } else if (operation == "fdiv") {
+    functionUnit->addSupportedOperation(FDiv);
+  }
+}
+
+// Helper function to configure memory operations.
+void configureMemoryOperations(CustomizableFunctionUnit *functionUnit, const std::string &operation) {
+  if (operation == "load") {
+    functionUnit->addSupportedOperation(ILoad);
+  } else if (operation == "store") {
+    functionUnit->addSupportedOperation(IStore);
+  } else if (operation == "load_indexed") {
+    functionUnit->addSupportedOperation(ILoadIndexed);
+  } else if (operation == "store_indexed") {
+    functionUnit->addSupportedOperation(IStoreIndexed);
+  } else if (operation == "alloca") {
+    functionUnit->addSupportedOperation(IAlloca);
+  }
+}
+
+// Helper function to configure logical operations.
+void configureLogicalOperations(CustomizableFunctionUnit *functionUnit, const std::string &operation) {
+  if (operation == "or") {
+    functionUnit->addSupportedOperation(IOr);
+  } else if (operation == "not") {
+    functionUnit->addSupportedOperation(INot);
+  } else if (operation == "icmp") {
+    functionUnit->addSupportedOperation(ICmp);
+  } else if (operation == "fcmp") {
+    functionUnit->addSupportedOperation(FCmp);
+  } else if (operation == "sel") {
+    functionUnit->addSupportedOperation(ISel);
+  }
+}
+
+// Helper function to configure type conversion operations.
+void configureTypeConversionOperations(CustomizableFunctionUnit *functionUnit, const std::string &operation) {
+  if (operation == "cast") {
+    functionUnit->addSupportedOperation(ICast);
+  } else if (operation == "sext") {
+    functionUnit->addSupportedOperation(ISExt);
+  } else if (operation == "zext") {
+    functionUnit->addSupportedOperation(IZExt);
+  } else if (operation == "shl") {
+    functionUnit->addSupportedOperation(IShl);
+  }
+}
+
+// Helper function to configure specialized operations.
+void configureSpecializedOperations(CustomizableFunctionUnit *functionUnit, const std::string &operation) {
+  if (operation == "vfmul") {
+    functionUnit->addSupportedOperation(VFMul);
+  } else if (operation == "fadd_fadd") {
+    functionUnit->addSupportedOperation(FAddFAdd);
+  } else if (operation == "fmul_fadd") {
+    functionUnit->addSupportedOperation(FMulFAdd);
+  } else if (operation == "return") {
+    functionUnit->addSupportedOperation(IReturn);
+  } else if (operation == "phi") {
+    functionUnit->addSupportedOperation(IPhi);
+  } else if (operation == "data_mov") {
+    functionUnit->addSupportedOperation(IDataMov);
+  } else if (operation == "ctrl_mov") {
+    functionUnit->addSupportedOperation(ICtrlMov);
+  } else if (operation == "reserve") {
+    functionUnit->addSupportedOperation(IReserve);
+  } else if (operation == "grant_predicate") {
+    functionUnit->addSupportedOperation(IGrantPredicate);
+  } else if (operation == "grant_once") {
+    functionUnit->addSupportedOperation(IGrantOnce);
+  } else if (operation == "grant_always") {
+    functionUnit->addSupportedOperation(IGrantAlways);
+  } else if (operation == "loop_control") {
+    functionUnit->addSupportedOperation(ILoopControl);
+  } else if (operation == "constant") {
+    functionUnit->addSupportedOperation(IConstant);
+  }
+}
+
+// Helper function to create a function unit for a specific operation.
+// Maps YAML operation names to OperationKind enum values and creates appropriate function units.
+void createFunctionUnitForOperation(Tile *tile, const std::string &operation, int &functionUnitId) {
+  auto functionUnit = std::make_unique<CustomizableFunctionUnit>(functionUnitId++);
+  
+  // Configures different types of operations using helper functions.
+  configureArithmeticOperations(functionUnit.get(), operation);
+  configureMemoryOperations(functionUnit.get(), operation);
+  configureLogicalOperations(functionUnit.get(), operation);
+  configureTypeConversionOperations(functionUnit.get(), operation);
+  configureSpecializedOperations(functionUnit.get(), operation);
+  
+  // TODO: Add support for unknown operations with warning instead of silent failure.
+  // This would help users identify typos in their YAML configuration.
+  
+  tile->addFunctionUnit(std::move(functionUnit));
+}
+
+// Helper function to configure tile function units based on operations.
+void configureTileFunctionUnits(Tile *tile, const std::vector<std::string> &operations, bool clearExisting = true) {
+  // Configures function units based on YAML operations specification.
+  // If clearExisting is true, this replaces any existing function units with the specified ones.
+  
+  if (clearExisting) {
+    tile->clearFunctionUnits();
+  }
+  
+  int functionUnitId = 0;
+  for (const auto &operation : operations) {
+    createFunctionUnitForOperation(tile, operation, functionUnitId);
+  }
+}
 
 //===----------------------------------------------------------------------===//
 // Tile
@@ -15,9 +145,8 @@ Tile::Tile(int id, int x, int y) {
   this->x = x;
   this->y = y;
 
-  // TODO: Add function units based on architecture specs.
-  // @Jackcuii, https://github.com/coredac/dataflow/issues/82.
-  addFunctionUnit(std::make_unique<FixedPointAdder>(0));
+  // Function units are now configured via YAML specification in Architecture constructor.
+  // The old hardcoded FixedPointAdder has been replaced with configurable function units.
 }
 
 int Tile::getId() const { return id; }
@@ -32,6 +161,14 @@ void Tile::linkDstTile(Link *link, Tile *tile) {
   out_links.insert(link);
   tile->src_tiles.insert(this);
   tile->in_links.insert(link);
+}
+
+void Tile::unlinkDstTile(Link *link, Tile *tile) {
+  assert(tile && "Cannot unlink from a null tile");
+  dst_tiles.erase(tile);
+  out_links.erase(link);
+  tile->src_tiles.erase(this);
+  tile->in_links.erase(link);
 }
 
 const std::set<Tile *> &Tile::getDstTiles() const { return dst_tiles; }
@@ -185,89 +322,205 @@ RegisterFileCluster::getRegisterFiles() const {
 // Architecture
 //===----------------------------------------------------------------------===//
 
-Architecture::Architecture(int width, int height) {
-  this->width = width;
-  this->height = height;
+// Helper method to initialize tiles in the architecture.
+void Architecture::initializeTiles(int width, int height) {
   const int num_tiles = width * height;
-
-  // Initializes tiles.
   tile_storage.reserve(num_tiles);
+  
   for (int y = 0; y < height; ++y) {
     for (int x = 0; x < width; ++x) {
       const int id = y * width + x;
-      // const int id = x * width + y;
       auto tile = std::make_unique<Tile>(id, x, y);
       id_to_tile[id] = tile.get();
       coord_to_tile[{x, y}] = tile.get();
       tile_storage.push_back(std::move(tile));
     }
   }
+}
 
-  // Initializes register file cluster for each tile.
+// Helper method to create register file cluster for a tile.
+void Architecture::createRegisterFileCluster(Tile *tile, int num_registers, int &reg_id) {
+  const int kNUM_REGS_PER_REGFILE = 8;  // Keep this fixed for now
+  const int kNUM_REGFILES_PER_CLUSTER = num_registers / kNUM_REGS_PER_REGFILE;
+  
+  RegisterFileCluster *register_file_cluster = new RegisterFileCluster(tile->getId());
+
+  // Createss registers as a register file.
+  // FIXME: We have to assign different IDs due to the hash function
+  // cannot distinguish between different register files..
+  for (int file_idx = 0; file_idx < kNUM_REGFILES_PER_CLUSTER; ++file_idx) {
+    RegisterFile *register_file = new RegisterFile(file_idx);
+    for (int reg_idx = 0; reg_idx < kNUM_REGS_PER_REGFILE; ++reg_idx) {
+      Register *reg = new Register(reg_id++);
+      register_file->addRegister(reg);
+    }
+    register_file_cluster->addRegisterFile(register_file);
+  }
+
+  tile->addRegisterFileCluster(register_file_cluster);
+}
+
+// Helper method to configure default tile settings.
+void Architecture::configureDefaultTileSettings(const TileDefaults& tileDefaults) {
   int reg_id = 0;
   for (int y = 0; y < height; ++y) {
     for (int x = 0; x < width; ++x) {
-      // Gets the tile by coordinates.
       Tile *tile = getTile(x, y);
-      const int kNUM_REGS_PER_REGFILE = 8;
-      const int kNUM_REGFILES_PER_CLUSTER = 4;
-
-      // Assembles register files into a cluster.
-      RegisterFileCluster *register_file_cluster =
-          new RegisterFileCluster(y * width + x);
-
-      // Creates registers as a register file.
-      // FIXME: We have to assign different IDs due to the hash function
-      // cannot distinguish between different register files..
-      for (int file_idx = 0; file_idx < kNUM_REGFILES_PER_CLUSTER; ++file_idx) {
-        RegisterFile *register_file = new RegisterFile(file_idx);
-        for (int reg_idx = 0; reg_idx < kNUM_REGS_PER_REGFILE; ++reg_idx) {
-          Register *reg = new Register(reg_id++);
-          register_file->addRegister(reg);
-        }
-        register_file_cluster->addRegisterFile(register_file);
-      }
-
-      // Adds register file cluster to the tile.
-      tile->addRegisterFileCluster(register_file_cluster);
-      llvm::errs() << "Tile (" << x << ", " << y
-                   << ") added register file cluster with ID: "
-                   << register_file_cluster->getId() << "\n";
+      
+      // Creates register file cluster with default capacity.
+      createRegisterFileCluster(tile, tileDefaults.num_registers, reg_id);
+      
+      // Configures function units based on tileDefaults.operations.
+      configureTileFunctionUnits(tile, tileDefaults.operations);
+      
+      // Sets default ports for the tile.
+      tile->setPorts(tileDefaults.default_ports);
     }
   }
+}
 
-  // TODO: Model topology based on the architecture specs.
-  // https://github.com/coredac/dataflow/issues/52.
+// Helper method to recreate register file cluster with new capacity.
+void Architecture::recreateRegisterFileCluster(Tile *tile, int num_registers) {
+  const int kNUM_REGS_PER_REGFILE = 8;  // Keep this fixed for now
+  const int kNUM_REGFILES_PER_CLUSTER = num_registers / kNUM_REGS_PER_REGFILE;
+  
+  // Remove existing register file cluster.
+  if (tile->getRegisterFileCluster()) {
+    delete tile->getRegisterFileCluster();
+  }
+  
+  // Creates new register file cluster with override capacity.
+  RegisterFileCluster *new_register_file_cluster = 
+      new RegisterFileCluster(tile->getId());
+  
+  // Creates registers with new capacity.
+  int reg_id = tile->getId() * 1000;  // Use tile ID as base to avoid conflicts
+  for (int file_idx = 0; file_idx < kNUM_REGFILES_PER_CLUSTER; ++file_idx) {
+    RegisterFile *register_file = new RegisterFile(file_idx);
+    for (int reg_idx = 0; reg_idx < kNUM_REGS_PER_REGFILE; ++reg_idx) {
+      Register *reg = new Register(reg_id++);
+      register_file->addRegister(reg);
+    }
+    new_register_file_cluster->addRegisterFile(register_file);
+  }
+  
+  // Add new register file cluster to the tile.
+  tile->addRegisterFileCluster(new_register_file_cluster);
+}
+
+// Helper method to apply tile overrides.
+void Architecture::applyTileOverrides(const std::vector<TileOverride>& tileOverrides) {
+  for (const auto &override : tileOverrides) {
+    Tile *tile = nullptr;
+    if (override.id >= 0) {
+      tile = getTile(override.id);
+    } else if (override.x >= 0 && override.y >= 0) {
+      tile = getTile(override.x, override.y);
+    }
+    
+    if (tile) {
+      // Overrides operations if specified.
+      if (!override.operations.empty()) {
+        configureTileFunctionUnits(tile, override.operations, true);
+      }
+      
+      // Overrides num_registers if specified.
+      if (override.num_registers > 0) {
+        recreateRegisterFileCluster(tile, override.num_registers);
+      }
+      
+      // Overrides ports if specified.
+      if (!override.ports.empty()) {
+        tile->setPorts(override.ports);
+      }
+      
+      // Overrides memory capacity if specified.
+      if (override.memory.capacity > 0) {
+        tile->setMemoryCapacity(override.memory.capacity);
+      }
+    }
+  }
+}
+
+// Helper method to create links between tiles.
+void Architecture::createLinks(const LinkDefaults& linkDefaults) {
   int link_id = 0;
   for (int j = 0; j < height; ++j) {
     for (int i = 0; i < width; ++i) {
-      // Gets the tile by coordinates.
       Tile *tile = getTile(i, j);
 
-      // Creates links to neighboring tiles.
+      // Createss links to neighboring tiles with default properties.
       if (i > 0) {
         auto link_towards_left = std::make_unique<Link>(link_id++);
+        link_towards_left->setLatency(linkDefaults.latency);
+        link_towards_left->setBandwidth(linkDefaults.bandwidth);
         link_towards_left->connect(tile, getTile(i - 1, j));
         link_storage.push_back(std::move(link_towards_left));
       }
       if (i < width - 1) {
         auto link_towards_right = std::make_unique<Link>(link_id++);
+        link_towards_right->setLatency(linkDefaults.latency);
+        link_towards_right->setBandwidth(linkDefaults.bandwidth);
         link_towards_right->connect(tile, getTile(i + 1, j));
         link_storage.push_back(std::move(link_towards_right));
       }
       if (j > 0) {
         auto link_towards_down = std::make_unique<Link>(link_id++);
+        link_towards_down->setLatency(linkDefaults.latency);
+        link_towards_down->setBandwidth(linkDefaults.bandwidth);
         link_towards_down->connect(tile, getTile(i, j - 1));
         link_storage.push_back(std::move(link_towards_down));
       }
       if (j < height - 1) {
         auto link_towards_up = std::make_unique<Link>(link_id++);
+        link_towards_up->setLatency(linkDefaults.latency);
+        link_towards_up->setBandwidth(linkDefaults.bandwidth);
         link_towards_up->connect(tile, getTile(i, j + 1));
         link_storage.push_back(std::move(link_towards_up));
       }
     }
   }
 }
+
+// Helper method to apply link overrides.
+void Architecture::applyLinkOverrides(const std::vector<LinkOverride>& linkOverrides) {
+  for (const auto &override : linkOverrides) {
+    if (override.id >= 0 && override.id < static_cast<int>(link_storage.size())) {
+      Link *link = link_storage[override.id].get();
+      if (link) {
+        if (override.latency > 0) {
+          link->setLatency(override.latency);
+        }
+        
+        if (override.bandwidth > 0) {
+          link->setBandwidth(override.bandwidth);
+        }
+        
+        if (!override.existence) {
+          removeLink(override.id);
+        }
+      }
+    }
+  }
+}
+
+// Main constructor - handles all cases internally.
+Architecture::Architecture(int width, int height, 
+                          const TileDefaults& tileDefaults,
+                          const std::vector<TileOverride>& tileOverrides,
+                          const LinkDefaults& linkDefaults,
+                          const std::vector<LinkOverride>& linkOverrides) {
+  this->width = width;
+  this->height = height;
+
+  // Initializes architecture components using helper methods.
+  initializeTiles(width, height);
+  configureDefaultTileSettings(tileDefaults);
+  applyTileOverrides(tileOverrides);
+  createLinks(linkDefaults);
+  applyLinkOverrides(linkOverrides);
+}
+
 
 Tile *Architecture::getTile(int id) {
   auto it = id_to_tile.find(id);
@@ -299,3 +552,26 @@ std::vector<Link *> Architecture::getAllLinks() const {
   }
   return all_links;
 }
+
+void Architecture::removeLink(int linkId) {
+  if (linkId < 0 || linkId >= static_cast<int>(link_storage.size())) {
+    return;
+  }
+  
+  Link *link = link_storage[linkId].get();
+  if (!link) {
+    return;
+  }
+  
+  Tile *srcTile = link->getSrcTile();
+  Tile *dstTile = link->getDstTile();
+  
+  if (srcTile && dstTile) {
+    // Remove the link from both tiles' connection sets
+    srcTile->unlinkDstTile(link, dstTile);
+  }
+  
+  // Marks the link as removed by setting it to null
+  link_storage[linkId].reset();
+}
+

--- a/lib/NeuraDialect/Mapping/mapping_util.cpp
+++ b/lib/NeuraDialect/Mapping/mapping_util.cpp
@@ -17,16 +17,67 @@ using namespace mlir::neura;
 namespace mlir {
 namespace neura {
 OperationKind getOperationKindFromMlirOp(Operation *op) {
-  if (isa<neura::AddOp>(op))
-    return IAdd;
-  if (isa<neura::MulOp>(op))
-    return IMul;
-  if (isa<neura::FAddOp>(op))
-    return FAdd;
-  if (isa<neura::FMulOp>(op))
-    return FMul;
-  // TODO: Complete the list here.
-  // @Jackcuii, https://github.com/coredac/dataflow/issues/82.
+  // Integer arithmetic operations
+  if (isa<neura::AddOp>(op)) return IAdd;
+  if (isa<neura::SubOp>(op)) return ISub;
+  if (isa<neura::MulOp>(op)) return IMul;
+  if (isa<neura::DivOp>(op)) return IDiv;
+  if (isa<neura::RemOp>(op)) return IRem;
+  
+  // Floating-point arithmetic operations
+  if (isa<neura::FAddOp>(op)) return FAdd;
+  if (isa<neura::FSubOp>(op)) return FSub;
+  if (isa<neura::FMulOp>(op)) return FMul;
+  if (isa<neura::FDivOp>(op)) return FDiv;
+  
+  // Memory operations
+  if (isa<neura::LoadOp>(op)) return ILoad;
+  if (isa<neura::StoreOp>(op)) return IStore;
+  if (isa<neura::LoadIndexedOp>(op)) return ILoadIndexed;
+  if (isa<neura::StoreIndexedOp>(op)) return IStoreIndexed;
+  if (isa<neura::AllocaOp>(op)) return IAlloca;
+  
+  // Logical operations
+  if (isa<neura::OrOp>(op)) return IOr;
+  if (isa<neura::NotOp>(op)) return INot;
+  if (isa<neura::ICmpOp>(op)) return ICmp;
+  if (isa<neura::FCmpOp>(op)) return FCmp;
+  if (isa<neura::SelOp>(op)) return ISel;
+  
+  // Type conversion operations
+  if (isa<neura::CastOp>(op)) return ICast;
+  if (isa<neura::SExtOp>(op)) return ISExt;
+  if (isa<neura::ZExtOp>(op)) return IZExt;
+  if (isa<neura::ShlOp>(op)) return IShl;
+  
+  // Vector operations
+  if (isa<neura::VFMulOp>(op)) return VFMul;
+  
+  // Fused operations
+  if (isa<neura::FAddFAddOp>(op)) return FAddFAdd;
+  if (isa<neura::FMulFAddOp>(op)) return FMulFAdd;
+  
+  // Control flow operations
+  if (isa<neura::ReturnOp>(op)) return IReturn;
+  if (isa<neura::PhiOp>(op)) return IPhi;
+  
+  // Data movement operations
+  if (isa<neura::DataMovOp>(op)) return IDataMov;
+  if (isa<neura::CtrlMovOp>(op)) return ICtrlMov;
+  
+  // Predicate operations
+  if (isa<neura::ReserveOp>(op)) return IReserve;
+  if (isa<neura::GrantPredicateOp>(op)) return IGrantPredicate;
+  if (isa<neura::GrantOnceOp>(op)) return IGrantOnce;
+  if (isa<neura::GrantAlwaysOp>(op)) return IGrantAlways;
+  
+  // Loop control operations
+  if (isa<neura::LoopControlOp>(op)) return ILoopControl;
+  
+  // Constant operations
+  if (isa<neura::ConstantOp>(op)) return IConstant;
+  
+  // Default fallback
   return IAdd;
 }
 

--- a/lib/NeuraDialect/Transforms/GenerateCodePass.cpp
+++ b/lib/NeuraDialect/Transforms/GenerateCodePass.cpp
@@ -18,6 +18,7 @@
 #include <unordered_set>
 
 #include "NeuraDialect/Architecture/Architecture.h"
+#include "NeuraDialect/Architecture/ArchitectureSpec.h"
 #include "NeuraDialect/NeuraOps.h"
 
 using namespace mlir;
@@ -185,7 +186,10 @@ struct Topology {
 
 static Topology getTopologyFromArchitecture(int columns, int rows) {
   Topology topo;
-  mlir::neura::Architecture arch(columns, rows);
+  mlir::neura::Architecture arch(columns, rows, mlir::neura::TileDefaults{}, 
+                                 std::vector<mlir::neura::TileOverride>{}, 
+                                 mlir::neura::LinkDefaults{}, 
+                                 std::vector<mlir::neura::LinkOverride>{});
 
   for (auto *tile : arch.getAllTiles()) {
     topo.tile_location[tile->getId()] = {tile->getX(), tile->getY()};

--- a/lib/NeuraDialect/Transforms/MapToAcceleratorPass.cpp
+++ b/lib/NeuraDialect/Transforms/MapToAcceleratorPass.cpp
@@ -1,7 +1,9 @@
 #include <deque>
 #include <memory>
+#include <fstream>
 
 #include "NeuraDialect/Architecture/Architecture.h"
+#include "NeuraDialect/Architecture/ArchitectureSpec.h"
 #include "NeuraDialect/Mapping/HeuristicMapping/HeuristicMapping.h"
 #include "NeuraDialect/Mapping/MappingState.h"
 #include "NeuraDialect/Mapping/mapping_util.h"
@@ -15,6 +17,9 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/YAMLParser.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace mlir;
@@ -22,6 +27,423 @@ using namespace mlir::neura;
 
 #define GEN_PASS_DEF_MAPTOACCELERATOR
 #include "NeuraDialect/NeuraPasses.h.inc"
+
+// Use the TileOverride from ArchitectureSpec.h
+
+// Helper function to parse tile defaults.
+bool parseTileDefaults(llvm::yaml::MappingNode *tileDefaultsMap, mlir::neura::TileDefaults &tileDefaults) {
+  for (auto &keyValuePair : *tileDefaultsMap) {
+    auto *keyNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getKey());
+    if (!keyNode) continue;
+    
+    llvm::SmallString<64> keyString;
+    llvm::StringRef keyRef = keyNode->getValue(keyString);
+    
+    if (keyRef == "num_registers") {
+      auto *valueNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getValue());
+      if (valueNode) {
+        llvm::SmallString<64> valueString;
+        llvm::StringRef valueRef = valueNode->getValue(valueString);
+        long long tempValue = 0;
+        if (!valueRef.getAsInteger(10, tempValue)) {
+          tileDefaults.num_registers = static_cast<int>(tempValue);
+        }
+      }
+    } else if (keyRef == "operations") {
+      auto *valueNode = llvm::dyn_cast_or_null<llvm::yaml::SequenceNode>(keyValuePair.getValue());
+      if (valueNode) {
+        tileDefaults.operations.clear();
+        for (auto &operationNode : *valueNode) {
+          auto *operationScalar = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(&operationNode);
+          if (operationScalar) {
+            llvm::SmallString<64> operationString;
+            llvm::StringRef operationRef = operationScalar->getValue(operationString);
+            tileDefaults.operations.push_back(operationRef.str());
+          }
+        }
+      }
+    } else if (keyRef == "default_ports") {
+      auto *valueNode = llvm::dyn_cast_or_null<llvm::yaml::SequenceNode>(keyValuePair.getValue());
+      if (valueNode) {
+        tileDefaults.default_ports.clear();
+        for (auto &portNode : *valueNode) {
+          auto *portScalar = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(&portNode);
+          if (portScalar) {
+            llvm::SmallString<64> portString;
+            llvm::StringRef portRef = portScalar->getValue(portString);
+            tileDefaults.default_ports.push_back(portRef.str());
+          }
+        }
+      }
+    }
+  }
+  return true;
+}
+
+// Helper function to parse tile override coordinates and ID.
+void parseTileOverrideCoordinates(llvm::yaml::MappingNode *overrideMap, mlir::neura::TileOverride &override) {
+  for (auto &keyValuePair : *overrideMap) {
+    auto *keyNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getKey());
+    if (!keyNode) continue;
+    
+    llvm::SmallString<64> keyString;
+    llvm::StringRef keyRef = keyNode->getValue(keyString);
+    
+    if (keyRef == "id") {
+      auto *valueNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getValue());
+      if (valueNode) {
+        llvm::SmallString<64> valueString;
+        llvm::StringRef valueRef = valueNode->getValue(valueString);
+        long long tempValue = 0;
+        if (!valueRef.getAsInteger(10, tempValue)) {
+          override.id = static_cast<int>(tempValue);
+        }
+      }
+    } else if (keyRef == "x") {
+      auto *valueNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getValue());
+      if (valueNode) {
+        llvm::SmallString<64> valueString;
+        llvm::StringRef valueRef = valueNode->getValue(valueString);
+        long long tempValue = 0;
+        if (!valueRef.getAsInteger(10, tempValue)) {
+          override.x = static_cast<int>(tempValue);
+        }
+      }
+    } else if (keyRef == "y") {
+      auto *valueNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getValue());
+      if (valueNode) {
+        llvm::SmallString<64> valueString;
+        llvm::StringRef valueRef = valueNode->getValue(valueString);
+        long long tempValue = 0;
+        if (!valueRef.getAsInteger(10, tempValue)) {
+          override.y = static_cast<int>(tempValue);
+        }
+      }
+    }
+  }
+}
+
+// Helper function to parse tile override operations and registers.
+void parseTileOverrideOperations(llvm::yaml::MappingNode *overrideMap, mlir::neura::TileOverride &override) {
+  for (auto &keyValuePair : *overrideMap) {
+    auto *keyNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getKey());
+    if (!keyNode) continue;
+    
+    llvm::SmallString<64> keyString;
+    llvm::StringRef keyRef = keyNode->getValue(keyString);
+    
+    if (keyRef == "operations") {
+      auto *valueNode = llvm::dyn_cast_or_null<llvm::yaml::SequenceNode>(keyValuePair.getValue());
+      if (valueNode) {
+        override.operations.clear();
+        for (auto &operationNode : *valueNode) {
+          auto *operationScalar = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(&operationNode);
+          if (operationScalar) {
+            llvm::SmallString<64> operationString;
+            llvm::StringRef operationRef = operationScalar->getValue(operationString);
+            override.operations.push_back(operationRef.str());
+          }
+        }
+      }
+    } else if (keyRef == "num_registers") {
+      auto *valueNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getValue());
+      if (valueNode) {
+        llvm::SmallString<64> valueString;
+        llvm::StringRef valueRef = valueNode->getValue(valueString);
+        long long tempValue = 0;
+        if (!valueRef.getAsInteger(10, tempValue)) {
+          override.num_registers = static_cast<int>(tempValue);
+        }
+      }
+    }
+  }
+}
+
+// Helper function to parse tile override ports and memory.
+void parseTileOverridePortsAndMemory(llvm::yaml::MappingNode *overrideMap, mlir::neura::TileOverride &override) {
+  for (auto &keyValuePair : *overrideMap) {
+    auto *keyNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getKey());
+    if (!keyNode) continue;
+    
+    llvm::SmallString<64> keyString;
+    llvm::StringRef keyRef = keyNode->getValue(keyString);
+    
+    if (keyRef == "ports") {
+      auto *valueNode = llvm::dyn_cast_or_null<llvm::yaml::SequenceNode>(keyValuePair.getValue());
+      if (valueNode) {
+        override.ports.clear();
+        for (auto &portNode : *valueNode) {
+          auto *portScalar = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(&portNode);
+          if (portScalar) {
+            llvm::SmallString<64> portString;
+            llvm::StringRef portRef = portScalar->getValue(portString);
+            override.ports.push_back(portRef.str());
+          }
+        }
+      }
+    } else if (keyRef == "memory") {
+      auto *valueNode = llvm::dyn_cast_or_null<llvm::yaml::MappingNode>(keyValuePair.getValue());
+      if (valueNode) {
+        for (auto &memoryKeyValuePair : *valueNode) {
+          auto *memoryKeyNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(memoryKeyValuePair.getKey());
+          if (!memoryKeyNode) continue;
+          
+          llvm::SmallString<64> memoryKeyString;
+          llvm::StringRef memoryKeyRef = memoryKeyNode->getValue(memoryKeyString);
+          
+          if (memoryKeyRef == "capacity") {
+            auto *memoryValueNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(memoryKeyValuePair.getValue());
+            if (memoryValueNode) {
+              llvm::SmallString<64> memoryValueString;
+              llvm::StringRef memoryValueRef = memoryValueNode->getValue(memoryValueString);
+              long long tempValue = 0;
+              if (!memoryValueRef.getAsInteger(10, tempValue)) {
+                override.memory.capacity = static_cast<int>(tempValue);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// Helper function to parse a single tile override.
+void parseSingleTileOverride(llvm::yaml::MappingNode *overrideMap, mlir::neura::TileOverride &override) {
+  parseTileOverrideCoordinates(overrideMap, override);
+  parseTileOverrideOperations(overrideMap, override);
+  parseTileOverridePortsAndMemory(overrideMap, override);
+}
+
+// Helper function to parse tile overrides.
+bool parseTileOverrides(llvm::yaml::SequenceNode *tileOverridesSeq, std::vector<mlir::neura::TileOverride> &tileOverrides) {
+  for (auto &overrideNode : *tileOverridesSeq) {
+    auto *overrideMap = llvm::dyn_cast_or_null<llvm::yaml::MappingNode>(&overrideNode);
+    if (!overrideMap) continue;
+
+    mlir::neura::TileOverride override;
+    parseSingleTileOverride(overrideMap, override);
+    tileOverrides.push_back(override);
+  }
+  return true;
+}
+
+// Helper function to parse link defaults.
+bool parseLinkDefaults(llvm::yaml::MappingNode *linkDefaultsMap, mlir::neura::LinkDefaults &linkDefaults) {
+  for (auto &keyValuePair : *linkDefaultsMap) {
+    auto *keyNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getKey());
+    if (!keyNode) continue;
+    
+    llvm::SmallString<64> keyString;
+    llvm::StringRef keyRef = keyNode->getValue(keyString);
+    
+    if (keyRef == "latency") {
+      auto *valueNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getValue());
+      if (valueNode) {
+        llvm::SmallString<64> valueString;
+        llvm::StringRef valueRef = valueNode->getValue(valueString);
+        long long tempValue = 0;
+        if (!valueRef.getAsInteger(10, tempValue)) {
+          linkDefaults.latency = static_cast<int>(tempValue);
+        }
+      }
+    } else if (keyRef == "bandwidth") {
+      auto *valueNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getValue());
+      if (valueNode) {
+        llvm::SmallString<64> valueString;
+        llvm::StringRef valueRef = valueNode->getValue(valueString);
+        long long tempValue = 0;
+        if (!valueRef.getAsInteger(10, tempValue)) {
+          linkDefaults.bandwidth = static_cast<int>(tempValue);
+        }
+      }
+    }
+  }
+  return true;
+}
+
+// Helper function to parse link override properties.
+void parseLinkOverrideProperties(llvm::yaml::MappingNode *overrideMap, mlir::neura::LinkOverride &override) {
+  for (auto &keyValuePair : *overrideMap) {
+    auto *keyNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getKey());
+    if (!keyNode) continue;
+    
+    llvm::SmallString<64> keyString;
+    llvm::StringRef keyRef = keyNode->getValue(keyString);
+    
+    if (keyRef == "id") {
+      auto *valueNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getValue());
+      if (valueNode) {
+        llvm::SmallString<64> valueString;
+        llvm::StringRef valueRef = valueNode->getValue(valueString);
+        long long tempValue = 0;
+        if (!valueRef.getAsInteger(10, tempValue)) {
+          override.id = static_cast<int>(tempValue);
+        }
+      }
+    } else if (keyRef == "latency") {
+      auto *valueNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getValue());
+      if (valueNode) {
+        llvm::SmallString<64> valueString;
+        llvm::StringRef valueRef = valueNode->getValue(valueString);
+        long long tempValue = 0;
+        if (!valueRef.getAsInteger(10, tempValue)) {
+          override.latency = static_cast<int>(tempValue);
+        }
+      }
+    } else if (keyRef == "bandwidth") {
+      auto *valueNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getValue());
+      if (valueNode) {
+        llvm::SmallString<64> valueString;
+        llvm::StringRef valueRef = valueNode->getValue(valueString);
+        long long tempValue = 0;
+        if (!valueRef.getAsInteger(10, tempValue)) {
+          override.bandwidth = static_cast<int>(tempValue);
+        }
+      }
+    }
+  }
+}
+
+// Helper function to parse link override tile IDs and existence.
+void parseLinkOverrideTilesAndExistence(llvm::yaml::MappingNode *overrideMap, mlir::neura::LinkOverride &override) {
+  for (auto &keyValuePair : *overrideMap) {
+    auto *keyNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getKey());
+    if (!keyNode) continue;
+    
+    llvm::SmallString<64> keyString;
+    llvm::StringRef keyRef = keyNode->getValue(keyString);
+    
+    if (keyRef == "src_tile_id") {
+      auto *valueNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getValue());
+      if (valueNode) {
+        llvm::SmallString<64> valueString;
+        llvm::StringRef valueRef = valueNode->getValue(valueString);
+        long long tempValue = 0;
+        if (!valueRef.getAsInteger(10, tempValue)) {
+          override.src_tile_id = static_cast<int>(tempValue);
+        }
+      }
+    } else if (keyRef == "dst_tile_id") {
+      auto *valueNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getValue());
+      if (valueNode) {
+        llvm::SmallString<64> valueString;
+        llvm::StringRef valueRef = valueNode->getValue(valueString);
+        long long tempValue = 0;
+        if (!valueRef.getAsInteger(10, tempValue)) {
+          override.dst_tile_id = static_cast<int>(tempValue);
+        }
+      }
+    } else if (keyRef == "existence") {
+      auto *valueNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getValue());
+      if (valueNode) {
+        llvm::SmallString<64> valueString;
+        llvm::StringRef valueRef = valueNode->getValue(valueString);
+        override.existence = (valueRef == "true" || valueRef == "True" || valueRef == "1");
+      }
+    }
+  }
+}
+
+// Helper function to parse a single link override.
+void parseSingleLinkOverride(llvm::yaml::MappingNode *overrideMap, mlir::neura::LinkOverride &override) {
+  parseLinkOverrideProperties(overrideMap, override);
+  parseLinkOverrideTilesAndExistence(overrideMap, override);
+}
+
+// Helper function to parse link overrides.
+bool parseLinkOverrides(llvm::yaml::SequenceNode *linkOverridesSeq, std::vector<mlir::neura::LinkOverride> &linkOverrides) {
+  for (auto &overrideNode : *linkOverridesSeq) {
+    auto *overrideMap = llvm::dyn_cast_or_null<llvm::yaml::MappingNode>(&overrideNode);
+    if (!overrideMap) continue;
+
+    mlir::neura::LinkOverride override;
+    parseSingleLinkOverride(overrideMap, override);
+    linkOverrides.push_back(override);
+  }
+  return true;
+}
+
+// Helper function to parse architecture YAML configuration.
+bool parseArchitectureYAML(llvm::yaml::Document &doc, int &width, int &height, 
+                          mlir::neura::TileDefaults &tileDefaults,
+                          std::vector<mlir::neura::TileOverride> &tileOverrides,
+                          mlir::neura::LinkDefaults &linkDefaults,
+                          std::vector<mlir::neura::LinkOverride> &linkOverrides) {
+  auto *root = doc.getRoot();
+  if (!root) {
+    llvm::errs() << "[MapToAcceleratorPass] Empty YAML document\n";
+    return false;
+  }
+  
+  auto *rootMap = llvm::dyn_cast<llvm::yaml::MappingNode>(root);
+  if (!rootMap) {
+    llvm::errs() << "[MapToAcceleratorPass] YAML root is not a mapping\n";
+    return false;
+  }
+
+  // Iterate root mapping ONCE; find 'architecture' and 'tile_defaults'.
+  for (auto &keyValuePair : *rootMap) {
+    auto *keyNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(keyValuePair.getKey());
+    if (!keyNode) continue;
+    
+    llvm::SmallString<64> keyString;
+    llvm::StringRef keyRef = keyNode->getValue(keyString);
+    
+    if (keyRef == "architecture") {
+      auto *architectureMap = llvm::dyn_cast_or_null<llvm::yaml::MappingNode>(keyValuePair.getValue());
+      if (!architectureMap) continue;
+
+      // Iterate architecture mapping ONCE; read width/height in the same pass.
+      for (auto &architectureKeyValuePair : *architectureMap) {
+        auto *architectureKeyNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(architectureKeyValuePair.getKey());
+        if (!architectureKeyNode) continue;
+        
+        llvm::SmallString<64> architectureKeyString;
+        llvm::StringRef architectureKeyRef = architectureKeyNode->getValue(architectureKeyString);
+        if (architectureKeyRef != "width" && architectureKeyRef != "height") continue;
+        
+        auto *architectureValueNode = llvm::dyn_cast_or_null<llvm::yaml::ScalarNode>(architectureKeyValuePair.getValue());
+        if (!architectureValueNode) continue;
+        
+        llvm::SmallString<64> architectureValueString;
+        llvm::StringRef architectureValueRef = architectureValueNode->getValue(architectureValueString);
+        long long tempValue = 0;
+        if (!architectureValueRef.getAsInteger(10, tempValue)) {
+          if (architectureKeyRef == "width") width = static_cast<int>(tempValue);
+          if (architectureKeyRef == "height") height = static_cast<int>(tempValue);
+        }
+      }
+        } else if (keyRef == "tile_defaults") {
+          auto *tileDefaultsMap = llvm::dyn_cast_or_null<llvm::yaml::MappingNode>(keyValuePair.getValue());
+          if (tileDefaultsMap) {
+            parseTileDefaults(tileDefaultsMap, tileDefaults);
+          }
+        } else if (keyRef == "tile_overrides") {
+          auto *tileOverridesSeq = llvm::dyn_cast_or_null<llvm::yaml::SequenceNode>(keyValuePair.getValue());
+          if (tileOverridesSeq) {
+            parseTileOverrides(tileOverridesSeq, tileOverrides);
+          }
+        } else if (keyRef == "link_defaults") {
+          auto *linkDefaultsMap = llvm::dyn_cast_or_null<llvm::yaml::MappingNode>(keyValuePair.getValue());
+          if (linkDefaultsMap) {
+            parseLinkDefaults(linkDefaultsMap, linkDefaults);
+          }
+        } else if (keyRef == "link_overrides") {
+          auto *linkOverridesSeq = llvm::dyn_cast_or_null<llvm::yaml::SequenceNode>(keyValuePair.getValue());
+          if (linkOverridesSeq) {
+            parseLinkOverrides(linkOverridesSeq, linkOverrides);
+          }
+        }
+  }
+
+  if (width <= 0 || height <= 0) {
+    width = -1;
+    height = -1;
+  }
+
+  return true;
+}
 
 namespace {
 struct MapToAcceleratorPass
@@ -72,8 +494,6 @@ struct MapToAcceleratorPass
       if (mappingMode_stringRef.empty()) {
         mappingMode_stringRef = "spatial-temporal";
       }
-      llvm::errs() << "[MapToAcceleratorPass] Using Mapping Mode: "
-                   << mappingMode_stringRef << "\n";
     } else {
       llvm::errs() << "[MapToAcceleratorPass] Unsupported mapping mode: "
                    << mappingMode_stringRef << "\n";
@@ -132,6 +552,50 @@ struct MapToAcceleratorPass
       return;
     }
 
+    // Handle architecture specification file
+    std::string architectureSpecFile = mlir::neura::getArchitectureSpecFile();
+    int yamlWidth = -1;
+    int yamlHeight = -1;
+    mlir::neura::TileDefaults yamlTileDefaults;
+    std::vector<mlir::neura::TileOverride> tileOverrides;
+    mlir::neura::LinkDefaults yamlLinkDefaults;
+    std::vector<mlir::neura::LinkOverride> linkOverrides;
+    if (!architectureSpecFile.empty()) {
+
+      // Use LLVM YAML parser to validate the YAML syntax (no mapping yet)
+      llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> bufferOrErr =
+          llvm::MemoryBuffer::getFile(architectureSpecFile);
+      if (!bufferOrErr) {
+        llvm::errs() << "[MapToAcceleratorPass] Failed to open architecture specification file: "
+                     << architectureSpecFile << "\n";
+        return;
+      }
+
+      llvm::SourceMgr sm;
+      sm.AddNewSourceBuffer(std::move(*bufferOrErr), llvm::SMLoc());
+      llvm::yaml::Stream yamlStream(sm.getMemoryBuffer(sm.getMainFileID())->getBuffer(), sm);
+
+      bool parseFailed = false;
+      llvm::yaml::Document &firstDoc = *yamlStream.begin();
+      (void)firstDoc; // ensure document is created
+      if (yamlStream.failed()) {
+        parseFailed = true;
+      }
+
+      if (parseFailed) {
+        llvm::errs() << "[MapToAcceleratorPass] YAML parse error in: "
+                     << architectureSpecFile << "\n";
+        return;
+      }
+
+      // Parse YAML configuration
+      if (!parseArchitectureYAML(firstDoc, yamlWidth, yamlHeight, yamlTileDefaults, tileOverrides, yamlLinkDefaults, linkOverrides)) {
+        return;
+      }
+
+    } else {
+    }
+
     module.walk([&](func::FuncOp func) {
       // Skips functions not targeting the neura accelerator.
       auto accel_attr = func->getAttrOfType<StringAttr>("accelerator");
@@ -168,8 +632,12 @@ struct MapToAcceleratorPass
         rec_mii = 1; // No recurrence cycles found, set MII to 1.
       }
 
-      // AcceleratorConfig config{/*numTiles=*/8}; // Example
-      Architecture architecture(4, 4);
+      // Construct architecture from YAML configuration
+      int archW = (yamlWidth > 0 ? yamlWidth : 4);
+      int archH = (yamlHeight > 0 ? yamlHeight : 4);
+      
+      // Always use full constructor with YAML configuration
+      Architecture architecture(archW, archH, yamlTileDefaults, tileOverrides, yamlLinkDefaults, linkOverrides);
       int res_mii = calculateResMii(func, architecture);
 
       const int possibleMinII = std::max(rec_mii, res_mii);
@@ -212,8 +680,6 @@ struct MapToAcceleratorPass
         if (mapping_strategy->map(sorted_ops_with_alap_levels, critical_ops,
                                   architecture, mapping_state)) {
           // success
-          llvm::errs() << "[MapToAcceleratorPass] Successfully mapped function "
-                       << func.getName() << "' with II = " << ii << "\n";
           mapping_state.dumpOpToLocs(); // logs to stderr
           mapping_state.encodeMappingState();
 

--- a/tools/mlir-neura-opt/mlir-neura-opt.cpp
+++ b/tools/mlir-neura-opt/mlir-neura-opt.cpp
@@ -7,12 +7,51 @@
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
+#include "llvm/Support/CommandLine.h"
 
 #include "Conversion/ConversionPasses.h"
 #include "NeuraDialect/NeuraDialect.h"
 #include "NeuraDialect/NeuraPasses.h"
+#include "NeuraDialect/Architecture/ArchitectureSpec.h"
+
+// Global variable to store architecture spec file path
+static std::string architectureSpecFile;
+static mlir::neura::TileDefaults tileDefaults;
+
+// Function to get the architecture spec file path
+std::string mlir::neura::getArchitectureSpecFile() {
+  return architectureSpecFile;
+}
+
+// Function to get tile defaults configuration
+mlir::neura::TileDefaults mlir::neura::getTileDefaults() {
+  return tileDefaults;
+}
 
 int main(int argc, char **argv) {
+  // Manually scan and strip --architecture-spec from argv, keep others for MlirOptMain.
+  std::vector<char *> forwardedArgs;
+  forwardedArgs.reserve(argc);
+  forwardedArgs.push_back(argv[0]);
+  for (int i = 1; i < argc; ++i) {
+    llvm::StringRef argRef(argv[i]);
+    if (argRef == "--architecture-spec") {
+      if (i + 1 < argc) {
+        architectureSpecFile = argv[i + 1];
+        ++i; // skip value
+        continue;
+      }
+    } else if (argRef.starts_with("--architecture-spec=")) {
+      architectureSpecFile = argRef.substr(strlen("--architecture-spec=")).str();
+      continue;
+    }
+    forwardedArgs.push_back(argv[i]);
+  }
+
+
+  int newArgc = static_cast<int>(forwardedArgs.size());
+  char **newArgv = forwardedArgs.data();
+
   // Registers MLIR dialects.
   mlir::DialectRegistry registry;
   registry.insert<mlir::neura::NeuraDialect>();
@@ -26,7 +65,15 @@ int main(int argc, char **argv) {
   mlir::registerPasses();
   mlir::registerViewOpGraphPass();
 
+  // Print architecture spec file info
+  if (!architectureSpecFile.empty()) {
+    llvm::errs() << "[mlir-neura-opt] Architecture specification file: " 
+                 << architectureSpecFile << "\n";
+  } else {
+    llvm::errs() << "[mlir-neura-opt] No architecture specification file provided, using default configuration\n";
+  }
+
   // Runs the MLIR optimizer.
   return mlir::asMainReturnCode(
-      mlir::MlirOptMain(argc, argv, "Neura Dialect Optimizer", registry));
+      mlir::MlirOptMain(newArgc, newArgv, "Neura Dialect Optimizer", registry));
 }


### PR DESCRIPTION
Adding option -architecture-spec="include/ArchitectureSpec/architecture.yaml"
Architecture Dimensions: Configurable width and height
Tile Configuration: Default and override support for num_registers, ports, operations, memory.capacity
Link Configuration: Default and override support for latency, bandwidth, and existence
Operation Mapping: Complete mapping of all 36 operations from NeuraOps.td to CustomizableFunctionUnit

TODO: 
-connectivity configure
-extensions
-tile_overrides.num_registers
-modify code_generate test