### PR TITLE
Fix use-after-free bug in tile_overrides register handling

### DIFF
--- a/lib/NeuraDialect/Architecture/Architecture.cpp
+++ b/lib/NeuraDialect/Architecture/Architecture.cpp
@@ -395,12 +395,8 @@ void Architecture::applyTileOverrides(const std::vector<TileOverride>& tile_over
       
       // Overrides num_registers if specified.
       if (override.num_registers > 0) {
-        // Removes existing register file cluster.
-        if (tile->getRegisterFileCluster()) {
-          delete tile->getRegisterFileCluster();
-        }
-        
         // Creates new register file cluster with override capacity.
+        // Note: addRegisterFileCluster handles deletion of existing cluster.
         // Uses tile ID as base to avoid conflicts with existing registers.
         int dummy_ref = 0;  // Not used when global_id_start is specified.
         createRegisterFileCluster(tile, override.num_registers, dummy_ref, tile->getId() * 1000);


### PR DESCRIPTION
Fixed a use-after-free crash in `applyTileOverrides` when overriding `num_registers`.

The issue was that `delete tile->getRegisterFileCluster()` left a dangling pointer, causing a crash when `addRegisterFileCluster` later accessed it.

Removed the redundant delete since `addRegisterFileCluster` already handles replacing the old cluster.