### PR TITLE
Optimize CI performance with ccache.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ env:
   LLVM_COMMIT: "6146a88f60492b520a36f8f8f3231e15f3cc6082"
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
   CCACHE_COMPRESS: "true"
-  CCACHE_MAXSIZE: "4G"
+  CCACHE_MAXSIZE: "1G"
 
 jobs:
   build:


### PR DESCRIPTION
This PR speeds up the CI test by:

- Adding ccache support to accelerate LLVM compilation.
- Using shallow cloning (`--revision`) to avoid fetching the entire LLVM history.
- Removing time-consuming MLIR tests.

After the initial caching of LLVM in the workflow, the subsequent build time will drop from ~3hours to ~10 minutes. See also [test data](https://github.com/BenkangPeng/dataflow/actions/runs/20360254937/job/58504106523)