### PR TITLE
[CI] Remove `git submodule update --remote --recursive`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,17 +29,16 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
-    
+
     # Update references
     - name: Git Submodule Update
       run: |
         git submodule update --init --recursive
-        git submodule update --remote --recursive
-    
+
     # install ninja
     - name: install ninja for LLVM build
       run: sudo apt-get install ninja-build
-    
+
     # install ccache
     - name: install ccache & lld
       run: |
@@ -59,7 +58,7 @@ jobs:
     # install graphviz
     - name: install graphviz
       run: sudo apt-get install graphviz
- 
+
     # setup LLVM
     - name: install a specific version of LLVM
       working-directory: ${{github.workspace}}
@@ -93,7 +92,7 @@ jobs:
 
         echo "CCache Status after build:"
         ccache -s
-        
+
         # Add LLVM tools to PATH
         echo "${{github.workspace}}/llvm-project/build/bin" >> $GITHUB_PATH
     # setup mlir-cgra
@@ -116,7 +115,7 @@ jobs:
         #   with:
         #     version: 12
         #     platform: x64
-        
+
         # # add path
         # - name: add paths
         #   working-directory: ${{github.workspace}}
@@ -159,4 +158,3 @@ jobs:
       run: |
         cd ${{github.workspace}}/test
         ${{github.workspace}}/llvm-project/build/bin/llvm-lit . -v
-


### PR DESCRIPTION
`git submodule update --remote --recursive` is a dangerous command which will updates submodules to their latest state rather than the pinned/specified commits. This may introduce CI failures.

The reason of CI failures of pr 247, 252, 254 is:

The relu test had been updated in submodule : https://github.com/tancheng/CGRA-Bench/compare/ccc0f9f...2beecc5

But we didn't update the content that FileCheck needs: https://github.com/coredac/dataflow/blob/main/test/e2e/relu/relu_kernel.mlir