### PR TITLE
Fix dialect registration in neura interpreter

### DIFF
--- a/test/e2e/relu/relu_kernel.mlir
+++ b/test/e2e/relu/relu_kernel.mlir
@@ -30,6 +30,9 @@
 // RUN: FileCheck %s --input-file=tmp-generated-instructions.yaml --check-prefix=YAML
 // RUN: FileCheck %s --input-file=tmp-generated-instructions.asm --check-prefix=ASM
 //
+// WIP: https://github.com/coredac/neura/issues/5
+// RN: neura-interpreter %t-mapping.mlir >> %t-dumped_output.txt
+//
 // Check the mapped MLIR contains key operations with full statements.
 // RUN: FileCheck %s --input-file=%t-mapping.mlir -check-prefix=MAPPING
 

--- a/tools/neura-interpreter/neura-interpreter.cpp
+++ b/tools/neura-interpreter/neura-interpreter.cpp
@@ -9,7 +9,9 @@
 #include "NeuraDialect/NeuraDialect.h"
 #include "NeuraDialect/NeuraOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/DLTI/DLTI.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
@@ -4038,8 +4040,8 @@ int main(int argc, char **argv) {
 
   // Initializes MLIR context and dialects.
   DialectRegistry registry;
-  registry
-      .insert<neura::NeuraDialect, func::FuncDialect, arith::ArithDialect>();
+  registry.insert<neura::NeuraDialect, func::FuncDialect, arith::ArithDialect,
+                  mlir::DLTIDialect, mlir::LLVM::LLVMDialect>();
 
   MLIRContext context;
   context.appendDialectRegistry(registry);


### PR DESCRIPTION
## Summary

This PR fixes a dialect registration issue in `neura-interpreter`.

Previously, `neura-interpreter` could not parse Neura MLIR files generated from the normal LLVM-import/e2e flow because the imported module may contain `dlti.dl_spec` metadata. This caused the interpreter to fail before it could execute the Neura dataflow IR.

The failure looked like:

```text
'dlti' attribute created with unregistered dialect
[neura-interpreter] Failed to parse MLIR input file
```

After this fix, `neura-interpreter` can parse the mapped ReLU IR generated by the existing `mlir-neura-opt` pipeline and proceed into dataflow execution.

## Testing

Tested manually on the ReLU e2e lowering flow.

### 1. Rebuild the updated tools

```bash
cd ~/dev/neura
ninja -C build neura-interpreter mlir-neura-opt
```

### 2. Generate LLVM IR for the ReLU kernel

```bash
mkdir -p /tmp/neura-step2-relu
cd /tmp/neura-step2-relu

clang++ -S -emit-llvm -O3 \
  -fno-vectorize -fno-unroll-loops \
  -std=c++17 \
  -o relu_kernel_full.ll \
  ~/dev/neura/test/benchmark/CGRA-Bench/kernels/relu/relu_int.cpp
```

### 3. Extract the kernel function and import it into MLIR

```bash
llvm-extract --rfunc=".*kernel.*" \
  relu_kernel_full.ll \
  -o relu_kernel_only.ll

mlir-translate --import-llvm \
  relu_kernel_only.ll \
  -o relu_kernel_imported.mlir
```

`mlir-translate` may print warnings such as:

```text
warning: unhandled data layout token: m:e
warning: unhandled data layout token: n8:16:32:64
```

These warnings are not fatal; `relu_kernel_imported.mlir` is still generated.

### 4. Lower and map the imported MLIR to Neura IR

```bash
mlir-neura-opt relu_kernel_imported.mlir \
  --assign-accelerator \
  --lower-llvm-to-neura \
  --promote-input-arg-to-const \
  --fold-constant \
  --canonicalize-return \
  --canonicalize-live-in \
  --leverage-predicated-value \
  --transform-ctrl-to-data-flow \
  --fold-constant \
  --insert-data-mov \
  --map-to-accelerator="mapping-strategy=heuristic" \
  --architecture-spec=$HOME/dev/neura/test/arch_spec/architecture.yaml \
  -o relu_neura_mapped.mlir
```

Confirmed that the mapped IR was generated:

```bash
ls -lh relu_neura_mapped.mlir
```

Observed:

```text
-rw-r--r-- 1 gnahzmit gnahzmit 15K May 19 18:18 relu_neura_mapped.mlir
```

### 5. Verify the interpreter behavior

Before this fix, running the interpreter on the mapped ReLU IR failed during parsing:

```bash
neura-interpreter relu_neura_mapped.mlir
```

Previous error:

```text
'dlti' attribute created with unregistered dialect
[neura-interpreter] Failed to parse MLIR input file
```

After this fix, the interpreter successfully parses the mapped ReLU IR and begins dataflow execution:

```bash
neura-interpreter relu_neura_mapped.mlir --verbose --dataflow
```

Observed output includes:

```text
[neura-interpreter]  Initial pending operation: %5 = neura.reserve ...
[neura-interpreter]  Initial pending operation: %1 = "neura.grant_once"() ...
[neura-interpreter]  DFG Iteration 0 - Beginning
[neura-interpreter]  Executing operation: %5 = neura.reserve ...
```

This confirms that the dialect registration issue is fixed.

The interpreter now proceeds past MLIR parsing and exposes the next execution-level issue:

```text
[neura-interpreter]  Executing operation: neura.yield ...
[neura-interpreter]  Unhandled op: neura.yield ...
[neura-interpreter]  Execution failed
```

That `neura.yield` handling is a separate follow-up issue and is not addressed by this PR.